### PR TITLE
fix: add link to integration docs

### DIFF
--- a/content/docs/features/virtual-branches/overview.mdx
+++ b/content/docs/features/virtual-branches/overview.mdx
@@ -31,7 +31,7 @@ You cannot use both GitButler virtual branches and normal Git branching commands
 The reason is that stock Git can only handle one branch at a time, it does not have tooling to use or understand multiple, so most commands having to do with the index or HEAD or branching (commit, branch, checkout, etc) may behave unexpectedly. Most importantly, do not use normal Git commit tooling or other GUIs.
 
 <Callout type="info">
-To understand why and how to get out of this, please read our integration-branch.md docs.
+To understand why and how to get out of this, please read our [integration branch](/features/virtual-branches/integration-branch) docs.
 </Callout>
 
 ## Base Branch


### PR DESCRIPTION
## ☕️ Reasoning

There was no link to the doc that explains how to switch between traditional Git and GitButler

## 🧢 Changes

Replace static text with a markdown link

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
