### PR TITLE
fix: whitelist 'Edit on GitHub' links for broken-link-checker

### DIFF
--- a/.github/broken-link-checker/src/index.ts
+++ b/.github/broken-link-checker/src/index.ts
@@ -206,7 +206,7 @@ async function brokenLinkChecker(): Promise<void> {
   // Options: https://www.npmjs.com/package/broken-link-checker#options
   const options = {
     excludeExternalLinks: false,
-    excludedKeywords: ["gitlab.com/-", "platform.openai.com"],
+    excludedKeywords: ["gitlab.com/-", "platform.openai.com", "https://github.com/gitbutlerapp/gitbutler-docs/blob/main/content/docs", "Edit on GitHub"],
     honorRobotExclusions: false,
     filterLevel: 0
   }


### PR DESCRIPTION
## ☕️ Reasoning

- Whenever new pages are added, they will by definition not be available under the `github.com/gitbutlerapp/gitbutler-docs/blob/main/...` links until the PR is merged.
- Therefore they'll always be  marked as "Broken" by the broken-link-checker action

## 🧢 Changes

- Whitelist links with the Keywrods `"Edit on GitHub"` and `"https ://github.com/gitbutlerapp/gitbutler-docs/blob/main/content/docs"`

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
