### PR TITLE
fix: gitbutler folder location on Windows

### DIFF
--- a/content/docs/development/debugging.mdx
+++ b/content/docs/development/debugging.mdx
@@ -22,7 +22,7 @@ Often the most helpful thing is to look at the logs. GitButler is a Tauri app, s
   </Tab>
   <Tab value="Windows">
   ```bash
-  C:\Users\[username]\AppData\Roaming\com.domain.appname\logs
+  C:\Users\[username]\AppData\Roaming\com.domain.app\logs
   ```
   </Tab>
   <Tab value="Linux">
@@ -76,7 +76,7 @@ GitButler also keeps it's own data about each of your projects. The virtual bran
   </Tab>
   <Tab value="Windows">
   ```bash
-  C:\Users\[username]\AppData\Roaming\com.domain.appname
+  C:\Users\[username]\AppData\Roaming\com.domain.app
   ```
   </Tab>
   <Tab value="Linux">

--- a/content/docs/features/virtual-branches/signing-commits.mdx
+++ b/content/docs/features/virtual-branches/signing-commits.mdx
@@ -86,7 +86,7 @@ Earlier versions of GitButler would only sign with it's generated SSH key. Altho
   </Tab>
   <Tab value="Windows">
   ```bash
-  C:\Users\[username]\AppData\Roaming\com.domain.appname\keys\ed25519.pub
+  C:\Users\[username]\AppData\Roaming\com.domain.app\keys\ed25519.pub
   ```
   </Tab>
   <Tab value="Linux">


### PR DESCRIPTION
The folder is named com.domain.app and not com.domain.appname.

Broken since 5e33e71 (feat: add more docs pages, 2024-06-24).
