### PR TITLE
Fix path to logs

### DIFF
--- a/content/docs/development/debugging.mdx
+++ b/content/docs/development/debugging.mdx
@@ -22,7 +22,7 @@ Often the most helpful thing is to look at the logs. GitButler is a Tauri app, s
   </Tab>
   <Tab value="Windows">
   ```bash
-  C:\Users\[username]\AppData\Roaming\com.domain.appname\logs
+  C:\Users\[username]\AppData\Roaming\com.gitbutler.app\logs
   ```
   </Tab>
   <Tab value="Linux">


### PR DESCRIPTION
## ☕️ Reasoning

The log path is wrong.

Here I found the logs:

![image](https://github.com/user-attachments/assets/866b44b0-8886-4244-b4b5-1fed71064176)


## 🧢 Changes

Fix path displayed to user.

