### PR TITLE
fix: grammar

### DIFF
--- a/content/docs/features/virtual-branches/butler-flow.mdx
+++ b/content/docs/features/virtual-branches/butler-flow.mdx
@@ -38,7 +38,7 @@ Virtual branches can be started and ended entirely independently of each other. 
 
 ### Collaboration
 
-All coworkers work, whether created and managed by GitButler or not, exists on the central server as normal Git branches. These will automatically be pulled down and kept up to date by GitButler and can be converted into virtual branches and applied to your working directory in addition to your branches.
+All coworkers' work, whether created and managed by GitButler or not, exists on the central server as normal Git branches. These will automatically be pulled down and kept up to date by GitButler and can be converted into virtual branches and applied to your working directory in addition to your branches.
 
 This allows you to integrate work from the rest of your team continuously and early, while still keeping non-dependent changes separated and independently reviewable and mergable. It allows you to review code without needing to entirely switch contexts, and to do so early and often in an executable environment.
 


### PR DESCRIPTION
## ☕️ Reasoning

Add an apostrophe to indicate a plural possessive noun for clearer reading.

## 🧢 Changes

`"coworkers" --> "coworkers'"`