### PR TITLE
fix: typo in releases.mdx page

### DIFF
--- a/content/docs/releases.mdx
+++ b/content/docs/releases.mdx
@@ -11,27 +11,27 @@ GitButler is released on a regular basis in two separate tracks. Their version n
 
 
 <Callout type="info">
-You can find the latest releases on our [GitHub Releases](https://github.com/gitbutlerapp/gitbutler/releases).
+You can find the download links and changelogs for the latest releases on our [GitHub Releases](https://github.com/gitbutlerapp/gitbutler/releases).
 </Callout>
 
 ## Platforms
 
 We bundle and ship GitButler for Mac OS, Windows, and Linux.
 
-#### Windows
+### Windows
 
 | Arch | Format | In-app updater |
 | --- | --- | --- |
 | `x86_64` | `msi` | <svg width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><rect width="256" height="256" fill="none"/><polyline points="88 136 112 160 168 104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="128" cy="128" r="96" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/></svg> |
 
-#### Mac OS
+### Mac OS
 
 | Arch | Format | In-app updater |
 | --- | --- | --- |
 | `x86_64` | `dmg` | <svg width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><rect width="256" height="256" fill="none"/><polyline points="88 136 112 160 168 104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="128" cy="128" r="96" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/></svg> |
 | `arm64` | `dmg` | <svg width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><rect width="256" height="256" fill="none"/><polyline points="88 136 112 160 168 104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="128" cy="128" r="96" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/></svg> |
 
-#### Linux
+### Linux
 
 | Arch | Format | In-app updater |
 | --- | --- | --- |
@@ -43,4 +43,4 @@ We bundle and ship GitButler for Mac OS, Windows, and Linux.
 >
 > We've recently upgraded to Tauri v2 (as of Nightly `0.5.845` and Release `0.13.9`), and it now requires `libwebkit2gtk-4.1`. This version of the package is not available in the repositories for Ubuntu 20.04 and older as well as Debian 11 and older.
 >
-> For more information, check out the  [link issue](https://github.com/tauri-apps/tauri/issues/9662) in the Tauri repository.
+> For more information, check out the [pinned issue](https://github.com/tauri-apps/tauri/issues/9662) in the Tauri repository.


### PR DESCRIPTION
## ☕️ Reasoning

- Fix typo in "link issue" to "pinned issue" for Tauri issue URL

## 🧢 Changes


<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
