### PR TITLE
fix: hide API Reference from sidebar

### DIFF
--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -10,8 +10,7 @@
     "features",
     "troubleshooting",
     "---Development---",
-    "development",
-    "api-reference",
+    "...development",
     "---Other---",
     "community",
     "releases"


### PR DESCRIPTION
## ☕️ Reasoning

- API Reference was growing to be just internal API endpoints, so more confusing for users than anything else

## 🧢 Changes

- Remove "API Reference" link from sidebar for now

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
