### PR TITLE
Fix old? log directory on Windows

### DIFF
--- a/content/docs/development/debugging.mdx
+++ b/content/docs/development/debugging.mdx
@@ -22,7 +22,7 @@ Often the most helpful thing is to look at the logs. GitButler is a Tauri app, s
   </Tab>
   <Tab value="Windows">
   ```bash
-  C:\Users\[username]\AppData\Roaming\com.gitbutler.app\logs
+  C:\Users\[username]\AppData\Local\com.gitbutler.app\logs
   ```
   </Tab>
   <Tab value="Linux">


### PR DESCRIPTION
## ☕️ Reasoning

On my Windows machine since ~2 weeks all new log files are written to `Local` and not to `Roaming`. Maybe something changed?

## 🧢 Changes

Replaced `Roaming` with `Local`. Maybe it is not so easy and both paths need to be displayed..

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
