### PR TITLE
Provide alternative log location for linux

### DIFF
--- a/content/docs/development/debugging.mdx
+++ b/content/docs/development/debugging.mdx
@@ -27,7 +27,8 @@ Often the most helpful thing is to look at the logs. GitButler is a Tauri app, s
   </Tab>
   <Tab value="Linux">
   ```bash
-  ~/.config/com.gitbutler.app/logs/
+  ~/.config/com.gitbutler.app/logs/        [OR]
+  ~/.local/share/com.gitbutler.app/logs/
   ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
Inspired by [this comment](https://github.com/gitbutlerapp/gitbutler/issues/5740#issuecomment-2519286594) over at GitButler, it was shown that on Linux the log-location is more diverse.

Let's inform about this to make log-retrieval on Linux easier.
