### PR TITLE
Update integration branch name to the new one.

### DIFF
--- a/content/docs/features/virtual-branches/integration-branch.mdx
+++ b/content/docs/features/virtual-branches/integration-branch.mdx
@@ -30,13 +30,13 @@ To keep Git command output for things that look at the index and HEAD (such as `
 
 For instance, if you have two files on Branch A and two files on Branch B, then `git status` will simply list four files as modified.
 
-However, to help out, we also write out a branch with a custom commit message that tries to explain the state of things and what is happening. This is written to a branch we own called `gitbutler/integration` and you shouldn't touch it.
+However, to help out, we also write out a branch with a custom commit message that tries to explain the state of things and what is happening. This is written to a branch we own called `gitbutler/workspace` and you shouldn't touch it.
 
 If you run `git log`, the first commit should be our custom commit message and the tree of that commit is the union of all the committed work on all your applied virtual branches, as though they were all merged together into one (something stock Git can understand).
 
 ## Committing, Branching, Checking Out
 
-However, if you try to use something that writes to HEAD, like `git commit` or `git checkout`, then you might have some headaches. By default, our client will simply overwrite the `gitbutler/integration` branch commit whenever something significant changes.
+However, if you try to use something that writes to HEAD, like `git commit` or `git checkout`, then you might have some headaches. By default, our client will simply overwrite the `gitbutler/workspace` branch commit whenever something significant changes.
 
 We won't touch the working directory in an unexpected way, so whatever you commit won't be lost, but the commit itself will be forgotten. Don't do branch stuff in stock Git while trying to use GitButler for now. We have ideas on how to make this somewhat doable in the future, but right now it's easier on everyone to stick with one or the other.
 


### PR DESCRIPTION
## ☕️ Reasoning
GitButler's integration branch name was renamed in the following Pull Request.
https://github.com/gitbutlerapp/gitbutler/pull/4729

The text in the document should be updated to the new one.


## 🧢 Changes
Rename the integration branch name from `gitbutler/integration` to `gitbutler/workspace` in the following page.

- Virtual Branches -> Integration Branches


**NOTE:** 
The file `recovering-stuff.mdx` was not changed because it contains the string `gitbutler/integration` as part of a git log message.