### PR TITLE
fix: update references to integration branch and gitbutler binary in paths + Linux debug notes

### DIFF
--- a/content/docs/development/debugging.mdx
+++ b/content/docs/development/debugging.mdx
@@ -10,6 +10,8 @@ If you get stuck or need help with anything, hit us up over on Discord, here's [
 
 <img src="/img/nothing-found.svg" className="w-56 mx-auto" />
 
+The first things to try is checking out the frontend related logs in the console by opening the developer tools in GitButler via the "View" -> "Developer Tools" menu option. Next, if you launch GitButler from the command line, you can view the backend logs directly in your terminal.
+
 ## Logs
 
 Often the most helpful thing is to look at the logs. GitButler is a Tauri app, so the logs are in your OS's [app log directory](https://docs.rs/tauri/1.8.1/tauri/api/path/fn.app_log_dir.html). This should be:
@@ -147,3 +149,20 @@ The `settings.json` are some top level preferences you've set.
 
 
 Finally, the `keys` directory holds the SSH key that we generate for you in case you don't want to go through creating your own. It's only used if you want to use it to sign commits or use it for authentication.
+
+## Linux
+
+### `glibc` Errors
+
+The Linux installation is currently being built in a GitHub Action with Ubuntu 24.04. This means support is limited to those installations using the same or newer version of `glibc`. Unfortunately we cannot build using earlier versions of Ubuntu due to another incompatibility with `libwebkit2gtk-4.1` and Tauri at the moment.
+
+If you're using an older distribution, you may be interested in trying our Flatpak package available on Flathub.
+
+### `Failed to create EGL image from DMABuf`
+
+If you start GitButler from the command line and see a bunch of these or similar `EGL` / `DMABuf` related messages printed to the console and are only getting a white screen to render, you can try launching GitButler with the following environment variables:
+
+- `WEBKIT_DISABLE_DMABUF_RENDERER=1`
+- `WEBKIT_DISABLE_COMPOSITING_MODE=1`
+
+This issue most likely stems from an incompatibility between your version of OpenGL (`mesa`) and `libwebkit2gtk-4.1`.

--- a/content/docs/development/debugging.mdx
+++ b/content/docs/development/debugging.mdx
@@ -27,8 +27,8 @@ Often the most helpful thing is to look at the logs. GitButler is a Tauri app, s
   </Tab>
   <Tab value="Linux">
   ```bash
-  ~/.config/com.gitbutler.app/logs/        [OR]
-  ~/.local/share/com.gitbutler.app/logs/
+  ~/.config/gitbutler/logs/        [OR]
+  ~/.local/share/gitbutler-tauri/logs/
   ```
   </Tab>
 </Tabs>
@@ -77,12 +77,12 @@ GitButler also keeps it's own data about each of your projects. The virtual bran
   </Tab>
   <Tab value="Windows">
   ```bash
-  C:\Users\[username]\AppData\Roaming\com.domain.appname
+  C:\Users\[username]\AppData\Roaming\com.gitbutler.app
   ```
   </Tab>
   <Tab value="Linux">
   ```bash
-  ~/.local/share/com.gitbutler.app/
+  ~/.local/share/gitbutler-tauri/
   ```
   </Tab>
 </Tabs>

--- a/content/docs/features/virtual-branches/signing-commits.mdx
+++ b/content/docs/features/virtual-branches/signing-commits.mdx
@@ -77,12 +77,12 @@ Earlier versions of GitButler would only sign with it's generated SSH key. Altho
   </Tab>
   <Tab value="Windows">
   ```bash
-  C:\Users\[username]\AppData\Roaming\com.domain.appname\keys\ed25519.pub
+  C:\Users\[username]\AppData\Roaming\com.gitbutler.app\keys\ed25519.pub
   ```
   </Tab>
   <Tab value="Linux">
   ```bash
-  [userdir]/.local/share/com.gitbutler.app/keys/ed25519.pub
+  ~/.local/share/gitbutler-tauri/keys/ed25519.pub
   ```
   </Tab>
 </Tabs>

--- a/content/docs/troubleshooting/recovering-stuff.mdx
+++ b/content/docs/troubleshooting/recovering-stuff.mdx
@@ -67,7 +67,7 @@ If you don't want to search through all your refs with `for-each-refs`, you can 
 
 ```bash title="Terminal"
 ❯ git log
-commit 2d8afe0ea811b5f24b9a6f84f6d024bb323a2db5 (HEAD -> gitbutler/integration)
+commit 2d8afe0ea811b5f24b9a6f84f6d024bb323a2db5 (HEAD -> gitbutler/workspace)
 Author: GitButler <gitbutler@gitbutler.com>
 Date:   Fri Feb 23 10:30:18 2024 +0100
 


### PR DESCRIPTION
## ☕️ Reasoning


## 🧢 Changes

- Update `gitbutler/integration` -> `gitbutler/workspace`
- Update path segment `com.gitbutler.app` -> `gitbutler-tauri` ~(**Needs verification on Mac OS**)~ on Linux only
- Add a few common linux debugging notes

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
