### PR TITLE
Add docs to descriptions

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,16 +33,16 @@ export default function Layout({ children }: { children: ReactNode }) {
 
 export const metadata: Metadata = {
   title: {
-    template: "%s | GitButler",
-    default: "GitButler"
+    template: "%s | GitButler Docs",
+    default: "GitButler Docs"
   },
   description:
     "GitButler is a new Source Code Management system designed to manage your branches, record and backup your work, be your Git client, help with your code and much more",
   openGraph: {
     images: "/cover.png",
     title: {
-      template: "%s | GitButler",
-      default: "GitButler"
+      template: "%s | GitButler Docs",
+      default: "GitButler Docs"
     },
     url: "https://docs.gitbutler.com",
     siteName: "GitButler Docs",
@@ -52,13 +52,13 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     creator: "@gitbutler",
-    title: "GitButler",
+    title: "GitButler Docs",
     description:
       "GitButler is a new Source Code Management system designed to manage your branches, record and backup your work, be your Git client, help with your code and much more",
     images: "/cover.png"
   },
   metadataBase: baseUrl,
-  applicationName: "GitButler",
+  applicationName: "GitButler Docs",
   robots: {
     index: true,
     follow: true


### PR DESCRIPTION
In our search results, the docs pages comes up as just "GitButler", which is a little confusing.

![CleanShot 2025-01-20 at 08 04 05@2x](https://github.com/user-attachments/assets/d0b718e3-5bc2-4b87-9a70-e15133855691)
