### PR TITLE
add path fallback for "/virtual-branches/"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,12 +13,12 @@
       "destination": "/why-gitbutler"
     },
     {
-      "source": "/features/virtual-branches",
-      "destination": "/features/branch-management/virtual-branches"
-    },
-    {
       "source": "/features/virtual-branches/verifying-commits",
       "destination": "/features/branch-management/signing-commits"
+    },
+    {
+      "source": "/features/virtual-branches/:path*",
+      "destination": "/features/branch-management/:path*"
     },
     {
       "source": "/features/stacked-branches",


### PR DESCRIPTION
This pull request updates the routing rules in `vercel.json` to improve how requests for virtual branches features are redirected. The main change is replacing a specific redirect with a more flexible pattern to ensure all relevant paths are correctly routed.

Routing improvements:

* Removed the explicit redirect from `/features/virtual-branches` to `/features/branch-management/virtual-branches`, and replaced it with a wildcard redirect from `/features/virtual-branches/:path*` to `/features/branch-management/:path*`, allowing all subpaths to be redirected appropriately.