### PR TITLE
Fix incorrect commands on cheat sheet

### DIFF
--- a/content/cheat.json
+++ b/content/cheat.json
@@ -74,11 +74,11 @@
           "level": "advanced"
         },
         {
-          "command": "but branch apply [branch]",
+          "command": "but apply [branch]",
           "description": "Apply (enable) a branch to your working directory"
         },
         {
-          "command": "but branch unapply [branch]",
+          "command": "but unapply [branch]",
           "description": "Unapply (disable) a branch from your working directory"
         },
         {


### PR DESCRIPTION
## 🧢 Changes

Updates the cheat sheet to use the correct command for apply and unapply.

## ☕️ Reasoning

It is unclear if these commands used to be located under the branch commands, but in `but 0.19.3` `but branch apply/unapply` do not exist - they are at the base `but`
