### PR TITLE
Improve docs site agent readiness

### DIFF
--- a/app/.well-known/agent-skills/[skillId]/SKILL.md/route.ts
+++ b/app/.well-known/agent-skills/[skillId]/SKILL.md/route.ts
@@ -1,0 +1,26 @@
+import { getAgentSkill } from "@/app/utils/agent-ready"
+
+interface Params {
+  skillId: string
+}
+
+export async function GET(_: Request, context: { params: Promise<Params> }): Promise<Response> {
+  const params = await context.params
+  const skill = getAgentSkill(params.skillId)
+
+  if (!skill) {
+    return new Response("Not found", {
+      status: 404,
+      headers: {
+        "content-type": "text/plain; charset=utf-8"
+      }
+    })
+  }
+
+  return new Response(`${skill.content}\n`, {
+    headers: {
+      "content-type": "text/markdown; charset=utf-8",
+      "cache-control": "public, max-age=3600"
+    }
+  })
+}

--- a/app/.well-known/agent-skills/index.json/route.ts
+++ b/app/.well-known/agent-skills/index.json/route.ts
@@ -1,0 +1,9 @@
+import { getAgentSkillsIndex } from "@/app/utils/agent-ready"
+
+export function GET(): Response {
+  return Response.json(getAgentSkillsIndex(), {
+    headers: {
+      "cache-control": "public, max-age=3600"
+    }
+  })
+}

--- a/app/.well-known/api-catalog/route.ts
+++ b/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,67 @@
+import { absoluteUrl } from "@/app/utils/site"
+
+export function GET(): Response {
+  const document = {
+    linkset: [
+      {
+        anchor: absoluteUrl("/"),
+        item: [
+          {
+            href: absoluteUrl("/guide"),
+            rel: "service-doc",
+            type: "text/html",
+            title: "Getting Started Guide"
+          },
+          {
+            href: absoluteUrl("/features/ai-integration/mcp-server"),
+            rel: "service-doc",
+            type: "text/html",
+            title: "GitButler MCP Server"
+          },
+          {
+            href: absoluteUrl("/api/search/openapi"),
+            rel: "service-desc",
+            type: "application/openapi+json",
+            title: "Docs Search API"
+          },
+          {
+            href: absoluteUrl("/api/status"),
+            rel: "status",
+            type: "application/json",
+            title: "Docs Status"
+          }
+        ]
+      },
+      {
+        anchor: absoluteUrl("/api/search"),
+        item: [
+          {
+            href: absoluteUrl("/api/search/openapi"),
+            rel: "service-desc",
+            type: "application/openapi+json",
+            title: "Docs Search API"
+          },
+          {
+            href: absoluteUrl("/"),
+            rel: "service-doc",
+            type: "text/html",
+            title: "GitButler Docs"
+          },
+          {
+            href: absoluteUrl("/api/status"),
+            rel: "status",
+            type: "application/json",
+            title: "Docs Status"
+          }
+        ]
+      }
+    ]
+  }
+
+  return new Response(JSON.stringify(document, null, 2), {
+    headers: {
+      "content-type": "application/linkset+json; charset=utf-8",
+      "cache-control": "public, max-age=3600"
+    }
+  })
+}

--- a/app/.well-known/mcp/server-card.json/route.ts
+++ b/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,37 @@
+import { absoluteUrl } from "@/app/utils/site"
+
+export function GET(): Response {
+  const document = {
+    name: "gitbutler-mcp",
+    description:
+      "GitButler's MCP server is exposed by the local `but mcp` command and helps coding agents checkpoint and organize repository changes.",
+    websiteUrl: absoluteUrl("/features/ai-integration/mcp-server"),
+    documentationUrl: absoluteUrl("/features/ai-integration/mcp-server"),
+    serverInfo: {
+      name: "GitButler MCP Server",
+      version: "1.0.0"
+    },
+    transports: [
+      {
+        type: "stdio",
+        command: "but",
+        args: ["mcp"]
+      }
+    ],
+    capabilities: {
+      tools: [
+        {
+          name: "gitbutler_update_branches",
+          description:
+            "Record agent-generated file changes in GitButler so they can be grouped into branches, checkpoints, and commits."
+        }
+      ]
+    }
+  }
+
+  return Response.json(document, {
+    headers: {
+      "cache-control": "public, max-age=3600"
+    }
+  })
+}

--- a/app/api/markdown/route.ts
+++ b/app/api/markdown/route.ts
@@ -1,0 +1,24 @@
+import { getPageMarkdown } from "@/app/utils/agent-markdown"
+
+export function GET(request: Request): Response {
+  const { searchParams } = new URL(request.url)
+  const pathname = searchParams.get("path") ?? "/"
+  const document = getPageMarkdown(pathname)
+
+  if (!document) {
+    return new Response("Not found", {
+      status: 404,
+      headers: {
+        "content-type": "text/plain; charset=utf-8"
+      }
+    })
+  }
+
+  return new Response(`${document.markdown}\n`, {
+    headers: {
+      "content-type": "text/markdown; charset=utf-8",
+      vary: "Accept",
+      "cache-control": "public, max-age=0, must-revalidate"
+    }
+  })
+}

--- a/app/api/search/openapi/route.ts
+++ b/app/api/search/openapi/route.ts
@@ -1,0 +1,73 @@
+import { absoluteUrl, getSiteOrigin } from "@/app/utils/site"
+
+export function GET(): Response {
+  const document = {
+    openapi: "3.1.0",
+    info: {
+      title: "GitButler Docs Search API",
+      version: "1.0.0",
+      description:
+        "Searches the GitButler documentation index and returns matching pages, headings, and text snippets."
+    },
+    servers: [
+      {
+        url: getSiteOrigin()
+      }
+    ],
+    paths: {
+      "/api/search": {
+        get: {
+          operationId: "searchDocs",
+          summary: "Search GitButler docs",
+          description: "Returns the best matching documentation entries for a query string.",
+          parameters: [
+            {
+              name: "query",
+              in: "query",
+              required: true,
+              schema: {
+                type: "string"
+              },
+              description: "Free-text query used to search the docs index."
+            }
+          ],
+          responses: {
+            "200": {
+              description: "Search results",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        id: { type: "string" },
+                        type: {
+                          type: "string",
+                          enum: ["page", "heading", "text"]
+                        },
+                        content: { type: "string" },
+                        url: {
+                          type: "string",
+                          examples: [absoluteUrl("/features/ai-integration/mcp-server")]
+                        }
+                      },
+                      required: ["id", "type", "content", "url"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return new Response(JSON.stringify(document, null, 2), {
+    headers: {
+      "content-type": "application/openapi+json; charset=utf-8",
+      "cache-control": "public, max-age=3600"
+    }
+  })
+}

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,7 @@
+export function GET(): Response {
+  return Response.json({
+    status: "ok",
+    service: "gitbutler-docs",
+    timestamp: new Date().toISOString()
+  })
+}

--- a/app/components/WebMcpTools.tsx
+++ b/app/components/WebMcpTools.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { useEffect } from "react"
+
+interface RegisteredTool {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  execute: (input: Record<string, unknown>) => Promise<unknown>
+}
+
+interface ModelContextNavigator extends Navigator {
+  modelContext?: {
+    provideContext?: (context: { tools: RegisteredTool[] }) => void
+    registerTool?: (tool: RegisteredTool) => void
+  }
+}
+
+function normalizeDocsPath(path: string): string {
+  if (!path || path === "/") {
+    return "/"
+  }
+
+  return path.startsWith("/") ? path : `/${path}`
+}
+
+export default function WebMcpTools(): null {
+  useEffect(() => {
+    const modelContext = (navigator as ModelContextNavigator).modelContext
+
+    if (!modelContext) {
+      return
+    }
+
+    const tools: RegisteredTool[] = [
+      {
+        name: "search_docs",
+        description: "Search the GitButler docs site and return matching pages and snippets.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Free-text query to search the documentation."
+            }
+          },
+          required: ["query"]
+        },
+        execute: async (input) => {
+          const query = typeof input.query === "string" ? input.query.trim() : ""
+
+          if (!query) {
+            return { error: "Missing required parameter: query" }
+          }
+
+          const response = await fetch(`/api/search?query=${encodeURIComponent(query)}`)
+
+          if (!response.ok) {
+            return { error: `Search request failed with ${response.status}` }
+          }
+
+          const results = (await response.json()) as Array<Record<string, unknown>>
+
+          return {
+            query,
+            results: results.slice(0, 8)
+          }
+        }
+      },
+      {
+        name: "get_page_markdown",
+        description: "Fetch a GitButler docs page as markdown for agent-friendly reading.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            path: {
+              type: "string",
+              description: "Docs path like /guide or /features/ai-integration/mcp-server."
+            }
+          },
+          required: ["path"]
+        },
+        execute: async (input) => {
+          const path = typeof input.path === "string" ? normalizeDocsPath(input.path.trim()) : "/"
+
+          const response = await fetch(`/api/markdown?path=${encodeURIComponent(path)}`, {
+            headers: {
+              Accept: "text/markdown"
+            }
+          })
+
+          if (!response.ok) {
+            return { error: `Page request failed with ${response.status}`, path }
+          }
+
+          return {
+            path,
+            content: await response.text()
+          }
+        }
+      }
+    ]
+
+    if (typeof modelContext.provideContext === "function") {
+      modelContext.provideContext({ tools })
+    }
+
+    if (typeof modelContext.registerTool === "function") {
+      tools.forEach((tool) => {
+        modelContext.registerTool?.(tool)
+      })
+    }
+  }, [])
+
+  return null
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,11 +6,10 @@ import type { ReactNode } from "react"
 import "@gitbutler/design-core/fonts"
 
 import Script from "next/script"
+import WebMcpTools from "@/app/components/WebMcpTools"
+import { getSiteUrl } from "@/app/utils/site"
 
-const baseUrl =
-  process.env.NODE_ENV === "development"
-    ? new URL("http://localhost:3000")
-    : new URL(`https://${process.env.VERCEL_URL}`)
+const baseUrl = getSiteUrl()
 
 const inter = Inter({
   subsets: ["latin"],
@@ -22,7 +21,10 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${inter.variable}`} suppressHydrationWarning>
       <body>
-        <Provider>{children}</Provider>
+        <Provider>
+          <WebMcpTools />
+          {children}
+        </Provider>
       </body>
       <Script
         async
@@ -46,7 +48,7 @@ export const metadata: Metadata = {
       template: "%s | GitButler Docs",
       default: "GitButler Docs"
     },
-    url: "https://docs.gitbutler.com",
+    url: baseUrl.toString(),
     siteName: "GitButler Docs",
     description:
       "GitButler is a new Source Code Management system designed to manage your branches, record and backup your work, be your Git client, help with your code and much more"

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "fs"
+
+export function GET(): Response {
+  const content = readFileSync("public/llms-full.txt", "utf-8")
+
+  return new Response(content, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=3600"
+    }
+  })
+}

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,39 @@
+import { absoluteUrl } from "@/app/utils/site"
+
+const lines = [
+  "User-agent: *",
+  "Allow: /",
+  "",
+  "User-agent: GPTBot",
+  "Allow: /",
+  "",
+  "User-agent: OAI-SearchBot",
+  "Allow: /",
+  "",
+  "User-agent: ChatGPT-User",
+  "Allow: /",
+  "",
+  "User-agent: ClaudeBot",
+  "Allow: /",
+  "",
+  "User-agent: Claude-Web",
+  "Allow: /",
+  "",
+  "User-agent: PerplexityBot",
+  "Allow: /",
+  "",
+  "User-agent: Google-Extended",
+  "Allow: /",
+  "",
+  "Content-Signal: ai-train=no, search=yes, ai-input=yes",
+  `Sitemap: ${absoluteUrl("/sitemap.xml")}`
+]
+
+export function GET(): Response {
+  return new Response(`${lines.join("\n")}\n`, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=3600"
+    }
+  })
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,8 @@
 import type { MetadataRoute } from "next"
 import { utils } from "./source"
+import { getSiteUrl } from "@/app/utils/site"
 
-const baseUrl =
-  process.env.NODE_ENV === "development"
-    ? new URL("http://localhost:3000")
-    : new URL(`https://${process.env.VERCEL_URL}`)
+const baseUrl = getSiteUrl()
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const url = (path: string): string => new URL(path, baseUrl).toString()

--- a/app/utils/agent-markdown.ts
+++ b/app/utils/agent-markdown.ts
@@ -1,0 +1,107 @@
+import { utils } from "@/app/source"
+import { absoluteUrl } from "@/app/utils/site"
+import { readFileSync } from "fs"
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---\n[\s\S]*?\n---\n*/u, "")
+}
+
+function stripImports(content: string): string {
+  return content.replace(/^import\s.+$/gmu, "")
+}
+
+function stripJsxComments(content: string): string {
+  return content.replace(/\{\/\*[\s\S]*?\*\/\}/gu, "")
+}
+
+function convertImageSections(content: string): string {
+  return content.replace(/<ImageSection([\s\S]*?)\/>/gu, (_, attributes: string) => {
+    const src = attributes.match(/\bsrc="([^"]+)"/u)?.[1]
+    const alt = attributes.match(/\balt="([^"]+)"/u)?.[1]
+    const subtitle = attributes.match(/\bsubtitle="([^"]+)"/u)?.[1]
+    const label = alt ?? subtitle ?? "Image"
+
+    if (!src) {
+      return `> ${label}`
+    }
+
+    const normalizedSrc =
+      src.startsWith("http://") || src.startsWith("https://") ? src : absoluteUrl(`/img/docs${src}`)
+
+    return `![${label}](${normalizedSrc})`
+  })
+}
+
+function convertTabs(content: string): string {
+  return content.replace(/<Tabs[^>]*>([\s\S]*?)<\/Tabs>/gu, (_, tabContent: string) => {
+    const tabs = [...tabContent.matchAll(/<Tab[^>]*value="([^"]+)"[^>]*>([\s\S]*?)<\/Tab>/gu)]
+
+    if (tabs.length === 0) {
+      return tabContent
+    }
+
+    return tabs.map(([, value, inner]) => `### ${value}\n\n${inner.trim()}`).join("\n\n")
+  })
+}
+
+function stripGenericJsx(content: string): string {
+  return content
+    .replace(/<\/?[A-Z][A-Za-z0-9]*(?:\s[^>]*)?>/gu, "")
+    .replace(/<\/?[a-z][a-z0-9-]*(?:\s[^>]*)?>/gu, "")
+}
+
+function normalizeWhitespace(content: string): string {
+  return content
+    .replace(/\n{3,}/gu, "\n\n")
+    .replace(/[ \t]+\n/gu, "\n")
+    .trim()
+}
+
+function toAgentMarkdown(rawContent: string): string {
+  return normalizeWhitespace(
+    stripGenericJsx(
+      convertTabs(
+        convertImageSections(stripJsxComments(stripImports(stripFrontmatter(rawContent))))
+      )
+    )
+  )
+}
+
+function normalizePath(pathname: string): string {
+  if (!pathname || pathname === "/") {
+    return "/"
+  }
+
+  const cleanedPath = pathname.startsWith("/") ? pathname : `/${pathname}`
+  return cleanedPath.replace(/\/+$/u, "")
+}
+
+export function getDocsPageByPath(pathname: string) {
+  const normalizedPath = normalizePath(pathname)
+  return utils.getPages().find((page) => page.url === normalizedPath)
+}
+
+export function getPageMarkdown(pathname: string) {
+  const page = getDocsPageByPath(pathname)
+
+  if (!page?.file?.path) {
+    return null
+  }
+
+  const rawContent = readFileSync(`content/docs/${page.file.path}`, "utf-8")
+  const markdownBody = toAgentMarkdown(rawContent)
+  const title = page.data.title.replace(/`/gu, "")
+  const canonicalUrl = absoluteUrl(page.url)
+  const descriptionBlock = page.data.description ? `${page.data.description}\n\n` : ""
+
+  return {
+    page,
+    title,
+    canonicalUrl,
+    markdown: `# ${title}
+
+Source: ${canonicalUrl}
+
+${descriptionBlock}${markdownBody}`.trim()
+  }
+}

--- a/app/utils/agent-ready.ts
+++ b/app/utils/agent-ready.ts
@@ -1,0 +1,103 @@
+import { createHash } from "crypto"
+import { absoluteUrl } from "@/app/utils/site"
+
+export interface AgentSkillDefinition {
+  id: string
+  name: string
+  description: string
+  type: string
+  content: string
+}
+
+function createSha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+export const agentSkillDefinitions: AgentSkillDefinition[] = [
+  {
+    id: "gitbutler-getting-started",
+    name: "GitButler Getting Started",
+    description: "Onboard a developer to the core GitButler desktop workflow.",
+    type: "documentation",
+    content: `# GitButler Getting Started
+
+Use this skill when you need to explain the first-run GitButler workflow to a user.
+
+## Recommended flow
+
+1. Read /guide as markdown by requesting it with \`Accept: text/markdown\`.
+2. Walk through target branch selection, authentication, creating a branch, committing work, and updating from upstream.
+3. Call out GitButler's strengths: parallel branches, commit editing, and undoing risky operations.
+
+## Key references
+
+- Guide: ${absoluteUrl("/guide")}
+- Desktop overview: ${absoluteUrl("/overview")}
+- Timeline: ${absoluteUrl("/features/timeline")}
+`
+  },
+  {
+    id: "gitbutler-mcp-setup",
+    name: "GitButler MCP Setup",
+    description: "Configure a coding agent to use GitButler's MCP server from the CLI.",
+    type: "documentation",
+    content: `# GitButler MCP Setup
+
+Use this skill when an agent needs to help a developer connect GitButler to Cursor, VS Code, or Claude Code.
+
+## Recommended flow
+
+1. Read the MCP setup guide at ${absoluteUrl("/features/ai-integration/mcp-server")} as markdown.
+2. Confirm that the \`but\` CLI is installed before configuring the MCP server.
+3. Use the documented \`but mcp\` stdio transport for agent integrations.
+4. Suggest an automation rule that calls the GitButler MCP tool after file edits.
+
+## Key references
+
+- MCP server guide: ${absoluteUrl("/features/ai-integration/mcp-server")}
+- AI overview: ${absoluteUrl("/features/ai-integration/ai-overview")}
+- Claude Code hooks: ${absoluteUrl("/features/ai-integration/claude-code-hooks")}
+`
+  },
+  {
+    id: "gitbutler-cli-reference",
+    name: "GitButler CLI Reference",
+    description: "Find the right GitButler CLI command and jump to the matching docs page.",
+    type: "documentation",
+    content: `# GitButler CLI Reference
+
+Use this skill when a user needs the GitButler CLI syntax, examples, or command documentation.
+
+## Recommended flow
+
+1. Search the docs site for the command name or topic.
+2. Prefer command-specific pages under /commands when they exist.
+3. If the user is learning the CLI, start with the overview and tutorial pages before jumping into a single command page.
+
+## Key references
+
+- CLI overview: ${absoluteUrl("/cli-overview")}
+- Commands overview: ${absoluteUrl("/commands/commands-overview")}
+- CLI tutorial: ${absoluteUrl("/cli-guides/cli-tutorial/tutorial-overview")}
+`
+  }
+]
+
+export function getAgentSkill(id: string): AgentSkillDefinition | undefined {
+  return agentSkillDefinitions.find((skill) => skill.id === id)
+}
+
+export function getAgentSkillsIndex() {
+  return {
+    $schema: "https://agentskills.io/schemas/agent-skills-index.v0.2.0.json",
+    version: "0.2.0",
+    generatedAt: new Date().toISOString(),
+    skills: agentSkillDefinitions.map((skill) => ({
+      name: skill.name,
+      type: skill.type,
+      description: skill.description,
+      url: absoluteUrl(`/.well-known/agent-skills/${skill.id}/SKILL.md`),
+      sha256: createSha256(skill.content)
+    }))
+  }
+}

--- a/app/utils/discovery.ts
+++ b/app/utils/discovery.ts
@@ -1,0 +1,66 @@
+import { absoluteUrl } from "@/app/utils/site"
+
+export interface DiscoveryLink {
+  href: string
+  rel: string
+  title?: string
+  type?: string
+}
+
+export function getDiscoveryLinks(): DiscoveryLink[] {
+  return [
+    {
+      href: absoluteUrl("/sitemap.xml"),
+      rel: "sitemap",
+      type: "application/xml"
+    },
+    {
+      href: absoluteUrl("/llms.txt"),
+      rel: "alternate",
+      title: "LLMs.txt",
+      type: "text/plain"
+    },
+    {
+      href: absoluteUrl("/.well-known/api-catalog"),
+      rel: "api-catalog",
+      title: "API Catalog",
+      type: "application/linkset+json"
+    },
+    {
+      href: absoluteUrl("/api/search/openapi"),
+      rel: "service-desc",
+      title: "Docs Search API",
+      type: "application/openapi+json"
+    },
+    {
+      href: absoluteUrl("/features/ai-integration/mcp-server"),
+      rel: "service-doc",
+      title: "GitButler MCP Server Docs",
+      type: "text/html"
+    },
+    {
+      href: absoluteUrl("/.well-known/agent-skills/index.json"),
+      rel: "describedby",
+      title: "Agent Skills Index",
+      type: "application/json"
+    }
+  ]
+}
+
+export function getDiscoveryLinkHeader(): string {
+  return getDiscoveryLinks()
+    .map((link) => {
+      const params = [`<${link.href}>`, `rel="${link.rel}"`]
+
+      if (link.type) {
+        params.push(`type="${link.type}"`)
+      }
+
+      if (link.title) {
+        params.push(`title="${link.title}"`)
+      }
+
+      return params.join("; ")
+    })
+    .join(", ")
+}

--- a/app/utils/metadata.ts
+++ b/app/utils/metadata.ts
@@ -1,34 +1,39 @@
-import { utils } from "@/app/source"
 import type { Page } from "@/app/source"
 import { readFileSync } from "fs"
+import { absoluteUrl } from "@/app/utils/site"
 
 /**
  * Extracts the first paragraph from MDX content
  */
 function extractFirstParagraph(mdxContent: string): string | undefined {
   // Remove frontmatter
-  const contentWithoutFrontmatter = mdxContent.replace(/^---\n[\s\S]*?\n---\n/, '')
-  
+  const contentWithoutFrontmatter = mdxContent.replace(/^---\n[\s\S]*?\n---\n/, "")
+
   // Remove import statements
-  const contentWithoutImports = contentWithoutFrontmatter.replace(/^import .+$/gm, '').trim()
-  
+  const contentWithoutImports = contentWithoutFrontmatter.replace(/^import .+$/gm, "").trim()
+
   // Split by double newlines to get paragraphs
   const paragraphs = contentWithoutImports.split(/\n\s*\n/)
-  
+
   for (const paragraph of paragraphs) {
     const cleaned = paragraph.trim()
     // Skip empty paragraphs, headings, and JSX components
-    if (cleaned && !cleaned.startsWith('#') && !cleaned.startsWith('<') && !cleaned.startsWith('```')) {
+    if (
+      cleaned &&
+      !cleaned.startsWith("#") &&
+      !cleaned.startsWith("<") &&
+      !cleaned.startsWith("```")
+    ) {
       // Remove any remaining markdown syntax
       return cleaned
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Remove links
-        .replace(/\*\*([^*]+)\*\*/g, '$1') // Remove bold
-        .replace(/\*([^*]+)\*/g, '$1') // Remove italic
-        .replace(/`([^`]+)`/g, '$1') // Remove inline code
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Remove links
+        .replace(/\*\*([^*]+)\*\*/g, "$1") // Remove bold
+        .replace(/\*([^*]+)\*/g, "$1") // Remove italic
+        .replace(/`([^`]+)`/g, "$1") // Remove inline code
         .trim()
     }
   }
-  
+
   return undefined
 }
 
@@ -41,19 +46,19 @@ function extractFirstImage(mdxContent: string): string | undefined {
   if (imageSectionMatch) {
     return imageSectionMatch[1]
   }
-  
+
   // Look for regular img tags
   const imgMatch = mdxContent.match(/<img[^>]*src="([^"]+)"/)
   if (imgMatch) {
     return imgMatch[1]
   }
-  
+
   // Look for markdown images
   const mdImageMatch = mdxContent.match(/!\[[^\]]*\]\(([^)]+)\)/)
   if (mdImageMatch) {
     return mdImageMatch[1]
   }
-  
+
   return undefined
 }
 
@@ -61,35 +66,37 @@ function extractFirstImage(mdxContent: string): string | undefined {
  * Generates dynamic metadata for a page
  */
 export async function generatePageMetadata(page: Page) {
+  const pageData = page.data as typeof page.data & { "share-image"?: string }
+
   // Read the raw content from the file system if not available on the page object
   let content: string | undefined
   try {
     if (page.file?.path) {
-      content = readFileSync(`content/docs/${page.file.path}`, 'utf-8')
+      content = readFileSync(`content/docs/${page.file.path}`, "utf-8")
     }
   } catch (error) {
-    console.warn('Failed to read file for metadata extraction:', error)
+    console.warn("Failed to read file for metadata extraction:", error)
   }
-  
+
   // Extract description from frontmatter or first paragraph
   let description = page.data.description
   if (!description && content) {
     description = extractFirstParagraph(content)
   }
-  
+
   // Extract image from frontmatter or first image in content
-  let image = (page.data as any)['share-image']
+  let image = pageData["share-image"]
   if (!image && content) {
     image = extractFirstImage(content)
   }
-  
+
   // Fallback to default cover image
   if (!image) {
-    image = '/cover.png'
+    image = "/cover.png"
   }
-  
+
   // Build the metadata
-  const title = page.data.title.replace(/`/g, '')
+  const title = page.data.title.replace(/`/g, "")
   const metadata = {
     title,
     description,
@@ -97,18 +104,18 @@ export async function generatePageMetadata(page: Page) {
       title,
       description,
       images: [image],
-      type: 'article' as const,
-      url: `https://docs.gitbutler.com${page.url}`,
-      siteName: 'GitButler Docs'
+      type: "article" as const,
+      url: absoluteUrl(page.url),
+      siteName: "GitButler Docs"
     },
     twitter: {
-      card: 'summary_large_image' as const,
+      card: "summary_large_image" as const,
       title,
       description,
       images: [image],
-      creator: '@gitbutler'
+      creator: "@gitbutler"
     }
   }
-  
+
   return metadata
 }

--- a/app/utils/site.ts
+++ b/app/utils/site.ts
@@ -1,0 +1,27 @@
+const DEFAULT_SITE_ORIGIN = "https://docs.gitbutler.com"
+
+export function getSiteOrigin(): string {
+  const explicitOrigin = process.env.NEXT_PUBLIC_BASE_URL ?? process.env.SITE_URL
+
+  if (explicitOrigin) {
+    return explicitOrigin.startsWith("http") ? explicitOrigin : `https://${explicitOrigin}`
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    return "http://localhost:3000"
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`
+  }
+
+  return DEFAULT_SITE_ORIGIN
+}
+
+export function getSiteUrl(): URL {
+  return new URL(getSiteOrigin())
+}
+
+export function absoluteUrl(path: string): string {
+  return new URL(path, getSiteUrl()).toString()
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,78 @@
+import { getDiscoveryLinkHeader } from "@/app/utils/discovery"
+import { NextRequest, NextResponse } from "next/server"
+
+const STATIC_PREFIXES = [
+  "/_next",
+  "/api",
+  "/fav",
+  "/img",
+  "/cache",
+  "/cli-examples",
+  "/oss",
+  "/.well-known"
+]
+
+const STATIC_FILES = new Set([
+  "/cover.png",
+  "/manifest.webmanifest",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/llms.txt",
+  "/llms-full.txt",
+  "/gitbutler-cheat-sheet-all.pdf",
+  "/gitbutler-cheat-sheet-basic.pdf"
+])
+
+function appendHeaderValue(existing: string | null, value: string): string {
+  if (!existing) {
+    return value
+  }
+
+  const parts = existing.split(",").map((part) => part.trim())
+
+  if (parts.includes(value)) {
+    return existing
+  }
+
+  return `${existing}, ${value}`
+}
+
+function isPageRequest(pathname: string): boolean {
+  if (pathname === "/") {
+    return true
+  }
+
+  if (STATIC_FILES.has(pathname)) {
+    return false
+  }
+
+  if (STATIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return false
+  }
+
+  return !/\.[a-z0-9]+$/iu.test(pathname)
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  const pathname = request.nextUrl.pathname
+
+  if (!isPageRequest(pathname)) {
+    return NextResponse.next()
+  }
+
+  const acceptsMarkdown = request.headers.get("accept")?.includes("text/markdown") ?? false
+  const response = acceptsMarkdown
+    ? NextResponse.rewrite(
+        new URL(`/api/markdown?path=${encodeURIComponent(pathname)}`, request.url)
+      )
+    : NextResponse.next()
+
+  response.headers.set("Link", getDiscoveryLinkHeader())
+  response.headers.set("Vary", appendHeaderValue(response.headers.get("Vary"), "Accept"))
+
+  return response
+}
+
+export const config = {
+  matcher: "/:path*"
+}


### PR DESCRIPTION
Before:
<img width="924" height="787" alt="Screenshot 2026-04-18 at 09 30 01" src="https://github.com/user-attachments/assets/d69ddd4f-9760-430a-92ee-f78da749449e" />

After:
<img width="799" height="801" alt="image" src="https://github.com/user-attachments/assets/d2e0dda7-848d-42f5-9523-03ffbcb37bde" />

## Summary
- add agent-facing discovery surfaces including robots.txt, llms.txt, an API catalog, an MCP server card, and an agent-skills index
- add markdown negotiation and homepage Link headers so agents can discover and fetch docs content in a machine-friendly form
- register WebMCP tools for docs search and page retrieval, and centralize canonical site URL handling across metadata and sitemap generation

## Why
The docs site was missing several low-effort agent-readiness signals that external scanners look for, especially robots.txt, Link headers, markdown negotiation, and machine-readable discovery documents. This makes the site easier for coding agents and scanners to understand without inventing unrelated OAuth or commerce surfaces.

## Validation
- pnpm build
- verified locally that /robots.txt returns 200 with AI crawler rules and a sitemap directive
- verified locally that page requests with Accept: text/markdown return text/markdown
- verified locally that /.well-known/api-catalog, /.well-known/mcp/server-card.json, and /.well-known/agent-skills/index.json return 200
- verified with a Puppeteer navigator.modelContext shim that the site registers the search_docs and get_page_markdown WebMCP tools on load