### PR TITLE
Clarify useful agent request guidance

### DIFF
--- a/content/docs/ai-agents/useful-requests.mdx
+++ b/content/docs/ai-agents/useful-requests.mdx
@@ -15,10 +15,8 @@ standing rules that always apply, see
 
 ## Commit changes
 
-With the baseline instructions from
-[Getting started](/ai-agents/getting-started#add-optional-agent-instructions),
-the agent commits on the dedicated GitButler branch for its session. It commits
-that session's changes there, not unrelated user or agent work.
+The agent commits the session's changes to its dedicated GitButler branch, not
+unrelated user or agent work.
 
 You can tell your agent:
 


### PR DESCRIPTION
## Summary

- Remove a repeated baseline-instructions reference from the useful agent requests page.
- Keep the commit example focused on what the agent commits and what it leaves alone.

## Validation

- Docs-only copy edit; no tests run.