### PR TITLE
docs(but): update but docs generation

### DIFF
--- a/content/docs/commands/but-branch.mdx
+++ b/content/docs/commands/but-branch.mdx
@@ -39,7 +39,8 @@ the new branch from. This allows you to create stacked branches.
 Deletes a branch from the workspace
 
 This will remove the branch and all its commits from the workspace.
-If the branch has unpushed commits, you will be prompted for confirmation.
+If the branch has unpushed commits, you will be prompted for confirmation
+unless the `--force` flag is used.
 
 **Usage:** `but branch delete <BRANCH_NAME>`
 
@@ -107,3 +108,24 @@ You can also choose to fetch and display review information, show files modified
 * `-f`, `--files` — Show files modified in each commit with line counts
 * `--ai` — Generate AI summary of the branch changes
 * `--check` — Check if the branch merges cleanly into upstream and identify conflicting commits
+
+### `but branch update`
+
+Update your local branch with the content of its remote counterpart.
+
+This allows you to resolve the divergence between your local branch and its
+tracked remote in different ways.
+
+**Usage:** `but branch update <BRANCH> [OPTIONS]`
+
+**Arguments:**
+
+* `<BRANCH>` — Name of the local branch to integrate (required)
+
+**Options:**
+
+* `-s`, `--strategy` `<STRATEGY>` — Strategy to use for the integration. If no strategy is specified, we default to pull-rebase (default: `pull-rebase`)
+* `--dry-run` — Preview the resulting branch state without persisting changes
+* `-v`, `--verbose` — Show additional dry-run details like the current divergence
+* `-i`, `--interactive` — Open the generated integration script in an editor
+

--- a/content/docs/commands/but-diff.mdx
+++ b/content/docs/commands/but-diff.mdx
@@ -5,7 +5,6 @@ description: "Displays the diff of changes in the repo."
 
 Without any arguments, it shows the diff of all uncommitted changes.
 Optionally, a CLI ID argument can be provided, which chan show the diff specific to
-
 - an uncommitted file
 - a branch
 - an entire stack
@@ -16,11 +15,10 @@ Optionally, a CLI ID argument can be provided, which chan show the diff specific
 
 ## Arguments
 
-- `<TARGET>` — The CLI ID of the entity to show the diff for
+* `<TARGET>` — The CLI ID of the entity to show the diff for
 
 ## Options
 
-- `--tui` — Open an interactive TUI diff viewer
-- `--no-tui` — Disable the interactive TUI diff viewer (overrides but.ui.tui config)
+* `--tui` — Open an interactive TUI diff viewer
+* `--no-tui` — Disable the interactive TUI diff viewer (overrides but.ui.tui config)
 
-For diff TUI usage and keybindings, see the [TUI guide](/gitbutler-tui#use-the-diff-tui).

--- a/content/docs/commands/but-reword.mdx
+++ b/content/docs/commands/but-reword.mdx
@@ -21,7 +21,7 @@ You can also use `but reword <branch-id>` to rename the branch.
 ## Options
 
 * `-m`, `--message` `<MESSAGE>` — The new commit message or branch name. If not provided, opens an editor
-* `-f`, `--format` — Format the existing commit message to 72-char line wrapping without opening an editor
+* `-f`, `--fix-formatting` — Format the existing commit message to 72-char line wrapping without opening an editor
 * `--diff` — Always show diff inside the editor.
 
 By default the diff will be shown unless it's large. The diff will always be shown if --diff is passed, regardless of the size of the diff. (default: `false`)

--- a/content/docs/commands/but-skill.mdx
+++ b/content/docs/commands/but-skill.mdx
@@ -116,3 +116,4 @@ but skill check --global
 * `-g`, `--global` — Only check global installations (in home directory)
 * `-l`, `--local` — Only check local installations (in current repository)
 * `-u`, `--update` — Automatically update any outdated skills found
+

--- a/content/docs/commands/but-stage.mdx
+++ b/content/docs/commands/but-stage.mdx
@@ -14,15 +14,16 @@ but stage --branch <branch>       # interactive, specific branch
 but stage <file-or-hunk> <branch> # direct staging
 ```
 
+For the interactive hunk picker workflow, see [https://docs.gitbutler.com/gitbutler-tui#stage-hunks-interactively](https://docs.gitbutler.com/gitbutler-tui#stage-hunks-interactively)
+
 **Usage:** `but stage [FILE_OR_HUNK] [BRANCH_POS] [OPTIONS]`
 
 ## Arguments
 
-- `<FILE_OR_HUNK>` — File or hunk ID to stage
-- `<BRANCH_POS>` — Branch to stage to (positional)
+* `<FILE_OR_HUNK>` — File or hunk ID to stage
+* `<BRANCH_POS>` — Branch to stage to (positional)
 
 ## Options
 
-- `-b`, `--branch` `<BRANCH>` — Branch to stage to (for interactive mode)
+* `-b`, `--branch` `<BRANCH>` — Branch to stage to (for interactive mode)
 
-For the interactive hunk picker workflow, see the [TUI guide](/gitbutler-tui#stage-hunks-interactively).

--- a/content/docs/commands/but-tui.mdx
+++ b/content/docs/commands/but-tui.mdx
@@ -3,15 +3,8 @@ title: "`but tui`"
 description: "Open a live terminal workspace for branches, commits, changes, and diffs."
 ---
 
-`but tui` opens the interactive terminal UI for the current GitButler workspace.
+The GitButler TUI provides a visual experience similar to the GitButler GUI - right in your
+terminal. For the full workflow and key bindings, see [https://docs.gitbutler.com/gitbutler-tui](https://docs.gitbutler.com/gitbutler-tui)
 
-Use it when you want a live workspace view in the terminal instead of static CLI
-output.
+**Usage:** `but tui`
 
-**Usage:** `but tui [OPTIONS]`
-
-## Options
-
-- `-j`, `--json` — Use JSON output format.
-
-For the full workflow and keybindings, see the [TUI guide](/gitbutler-tui).

--- a/scripts/update-manpages.sh
+++ b/scripts/update-manpages.sh
@@ -38,7 +38,7 @@ rm -f cli-docs/*
 
 # Regenerate documentation using cargo
 echo "Regenerating CLI documentation with cargo..."
-cargo run --bin but-clap
+cargo run --bin but-clap --features raw-clap-docs
 
 echo "Documentation files regenerated successfully!"
 echo


### PR DESCRIPTION
Updates the `but` docs generation script to use the new `raw-clap-docs` feature flag.

Also refreshes all docs - this removes some handwritten comments that we
probably want to port to the actual docs.

This contains the ported docs from https://github.com/gitbutlerapp/gitbutler/pull/14267