### PR TITLE
ci: bump docs to release/0.20.3

### DIFF
--- a/scripts/current_docs_version.txt
+++ b/scripts/current_docs_version.txt
@@ -1,1 +1,1 @@
-nightly/0.5.2077
+release/0.20.3


### PR DESCRIPTION
We don't want to run the update script for 0.20.3 as it does not contain some docs that were initially manually added in `gitbutler-docs`, and then ported over to the actual CLI docs source.

Next release should be good!