### PR TITLE
docs: document `but agent` and simplify agent setup

### DIFF
--- a/content/docs/ai-agents/getting-started.mdx
+++ b/content/docs/ai-agents/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Install `but`, install the GitButler agent skill, and add a baseline version-control policy for coding agents.
+description: Install `but`, run `but agent setup`, and give coding agents a GitButler version-control policy.
 ---
 
 This page is for coding agents that can read local instruction files and run
@@ -20,36 +20,42 @@ curl -fsSL https://gitbutler.com/install.sh | sh
 See [Installation and setup](/cli-guides/installation) for the full CLI install
 options.
 
-## Install the GitButler skill
+## Run the agent setup wizard
 
-Run the installer from the same repository:
+From the repository where the agent will work, run:
 
 ```sh
-but skill install
+but agent setup
 ```
 
-The installer prompts for scope first: current repository or global home
-directory. It then prompts for the skill format. Current formats include Agent
-Skills (`.agents/skills`), Claude Code, OpenCode, Codex, GitHub Copilot, Cursor,
-and Windsurf.
+The wizard asks which agents you use, where the setup applies, and which
+workflow preferences you want. It can:
 
-For custom paths, global installs, non-interactive updates, and skill checks,
-see [`but skill`](/commands/but-skill).
+- install the GitButler skill for Codex, Claude Code, Cursor, GitHub Copilot,
+  Windsurf / Devin, OpenCode, or Agent Skills;
+- save workflow instructions globally, in this repository, or both;
+- run `but setup` for this repository when GitButler needs workspace mode.
+
+Before it writes anything, the wizard shows the skill install paths, instruction
+files, any repository setup step, and the exact generated text.
+
+`but agent` with no subcommand starts the same wizard. For command details, see
+[`but agent`](/commands/but-agent).
+
+The wizard installs the skill for you. To update an installed skill later
+without rerunning the wizard, use [`but skill`](/commands/but-skill).
 
 ## Set up the repository
 
 GitButler currently needs the repository in workspace mode for its multi-branch
-model: multiple GitButler branches in one working directory.
-
-From the repository where the agent will work, run:
+model: multiple GitButler branches in one working directory. The setup wizard
+runs this for you when needed. You can also run it yourself:
 
 ```sh
 but setup
 ```
 
-You can also skip this step and let the agent run `but setup` when it first
-needs GitButler. For the full list of setup changes, see
-[`but setup`](/commands/but-setup).
+For the full list of setup changes, see [`but setup`](/commands/but-setup).
 
 GitButler is working toward a plain Git mode that switches into a workspace only
 when multiple concurrent branches are needed. Follow
@@ -58,46 +64,18 @@ for that work.
 
 ## Add optional agent instructions
 
-The GitButler skill tells the agent how to use `but`. Your own instructions
-tell the agent what behavior you want.
+The wizard can write common workflow preferences for you: folding small fixes
+into the right commits, splitting mixed work, stacking dependent branches,
+updating from the target branch, opening draft PRs, using a publish phrase,
+naming branches, following commit-message conventions, and creating checkpoint
+commits.
 
-Put project defaults in a repository instruction file such as `AGENTS.md` or
-`CLAUDE.md`. Put personal defaults in a global instruction file such as
-`~/.codex/AGENTS.md`, `~/.claude/CLAUDE.md`, Cursor rules, Copilot custom
-instructions, or the equivalent for your tool.
+Use [Tuning agent behavior](/ai-agents/tuning-agent-behavior) when you want to
+read the policies before choosing them, adjust them after the wizard runs, or
+copy individual snippets by hand.
 
-These files steer agent behavior; they are not access controls. Use your usual
-repository permissions and branch protection for hard limits.
-
-Use this baseline to keep agent work isolated:
-
-```md
-## Version control
-
-- Use GitButler (`but`) for version-control write operations, including
-  branching, committing, pushing, and history edits.
-- Assume multiple agents may be working in this repository. Do not move, amend,
-  squash, discard, commit, push, or otherwise modify another agent's work unless
-  the user asks.
-- Use a dedicated GitButler branch for each agent session, unless the user asks
-  for a different branch structure. Commit only changes that belong to that
-  session.
-- Do not push or open pull requests unless the user asks.
-- Keep commit messages and pull request descriptions succinct: explain what
-  changed, why it changed, and any important decision.
-```
-
-You can also tune the agent to:
-
-- amend local fixes into existing commits;
-- create checkpoint commits and tidy them before review;
-- create stacked pull requests for dependent work;
-- follow your branch and commit naming conventions;
-- publish, update from main, or create recovery points only when your policy
-  allows it.
-
-For copyable snippets, see
-[Tuning agent behavior](/ai-agents/tuning-agent-behavior).
+These instructions steer agent behavior; they are not access controls. Use your
+usual repository permissions and branch protection for hard limits.
 
 For prompt examples that ask for specific branch and commit outcomes, see
 [Useful requests](/ai-agents/useful-requests).

--- a/content/docs/ai-agents/overview.mdx
+++ b/content/docs/ai-agents/overview.mdx
@@ -17,6 +17,23 @@ You decide how far the agent goes. You can tell it to stop after local commits,
 or you can allow it to push and open pull requests. GitButler gives the agent
 version-control commands; your instructions decide when it stops.
 
+## Quick start
+
+Run this from the repository where your agent will work:
+
+```sh
+but agent setup
+```
+
+The wizard can install the GitButler skill, write GitButler version-control
+instructions for your agent, and prepare the repository with `but setup` when
+GitButler needs workspace mode. It shows the files and exact instructions before
+writing anything.
+
+For the full setup path, see [Getting started](/ai-agents/getting-started). To
+choose or adjust the policies by hand, see
+[Tuning agent behavior](/ai-agents/tuning-agent-behavior).
+
 ## What agents can do with GitButler
 
 - **Parallel branches in one workspace.** An agent can create separate branches

--- a/content/docs/ai-agents/parallel-agents.mdx
+++ b/content/docs/ai-agents/parallel-agents.mdx
@@ -31,8 +31,8 @@ instead of stacking the fix on the feature.
 For more background on the branch model, see
 [Parallel branches](/features/branch-management/virtual-branches).
 
-The baseline `Version control` instructions from
-[Getting started](/ai-agents/getting-started#add-optional-agent-instructions)
+The `Version control` instructions written by `but agent setup`
+(see [Getting started](/ai-agents/getting-started#add-optional-agent-instructions))
 are useful if you want to steer commit behavior, but they are not a separate
 parallel-agent setup step.
 

--- a/content/docs/ai-agents/tuning-agent-behavior.mdx
+++ b/content/docs/ai-agents/tuning-agent-behavior.mdx
@@ -3,11 +3,13 @@ title: Tuning agent behavior
 description: Add optional instruction snippets that steer how coding agents amend, checkpoint, stack, publish, and recover work with GitButler.
 ---
 
-Add these optional bullets under the same `## Version control` section as the
-baseline from
-[Getting started](/ai-agents/getting-started#add-optional-agent-instructions).
-Use this page as a menu: copy only the policies you want for the repository and
-agent you are using.
+`but agent setup` can write many of these policies for you. Start with
+[Getting started](/ai-agents/getting-started) when you want the wizard path; use
+this page when you want to understand, copy, or adjust individual policies.
+
+Add these optional bullets under the same `## Version control` section as your
+baseline instructions. Use this page as a menu: copy only the policies you want
+for the repository and agent you are using.
 
 ## Amend local fixes into the right commits
 

--- a/content/docs/cli-guides/cli-tutorial/ai-stuff.mdx
+++ b/content/docs/cli-guides/cli-tutorial/ai-stuff.mdx
@@ -1,10 +1,10 @@
 ---
 title: Working with AI
-description: Use AI-backed CLI options and install the GitButler skill for coding agents.
+description: Use AI-backed CLI options and set up GitButler for coding agents.
 ---
 
 Use `--ai` when you want the CLI to generate text for a single command. Use
-`but skill install` when you want a coding agent to use GitButler's
+`but agent setup` when you want a coding agent to use GitButler's
 version-control workflow.
 
 ## `--ai` options
@@ -30,18 +30,20 @@ More commands will gain `--ai` support over time.
 
 </Callout>
 
-## `but skill install`
+## `but agent setup`
 
-If your coding agent can read skills, install the GitButler skill with
-`but skill install`.
+Run the setup wizard from the repository where your coding agent will work:
 
 ```bash
-but skill install
+but agent setup
 ```
 
-The command prompts for install scope and skill format. It can install local or
-global skills for Agent Skills (`.agents`), Claude Code, OpenCode, Codex, GitHub
-Copilot, Cursor, and Windsurf.
+The wizard can install the GitButler skill, save workflow preferences in
+supported agent instruction files, and run `but setup` for the repository when
+GitButler needs workspace mode.
+
+Use `but skill install` when you only want to install or update the skill files
+without writing workflow instructions.
 
 To update an existing install without going through the prompts, run:
 
@@ -54,7 +56,7 @@ GitButler.
 
 ## Agent workflow docs
 
-`but skill install` is only the install step. For the full workflow:
+For the full workflow:
 
 - Start with [AI agents overview](/ai-agents/overview).
 - Install and configure the skill with

--- a/content/docs/commands/but-agent.mdx
+++ b/content/docs/commands/but-agent.mdx
@@ -1,0 +1,47 @@
+---
+title: "`but agent`"
+description: "Set up GitButler for AI coding agents."
+---
+
+Use `but agent setup` to install GitButler agent skills and write workflow
+instructions into supported agent instruction files. To install or update the
+skill files without writing instructions, use
+[`but skill`](/commands/but-skill).
+
+Running `but agent` with no subcommand starts the same wizard.
+
+## Examples
+
+Start the interactive setup wizard:
+
+```text
+but agent setup
+```
+
+Print the default workflow instructions without modifying files:
+
+```text
+but agent setup --print
+```
+
+**Usage:** `but agent [COMMAND]`
+
+## Subcommands
+
+### `but agent setup`
+
+Configure GitButler skills and workflow instructions for coding agents.
+
+The wizard asks which agents you use, whether setup applies to this repository,
+globally, or both, and which workflow preferences to include. Before
+writing, it shows the skill install paths, instruction files, any repository
+`but setup` step, and the exact generated text.
+
+In a non-interactive terminal, use `--print`.
+
+**Usage:** `but agent setup [OPTIONS]`
+
+**Options:**
+
+* `--print` - Print the default workflow instructions without prompting or
+  modifying files

--- a/content/docs/commands/but-skill.mdx
+++ b/content/docs/commands/but-skill.mdx
@@ -6,6 +6,10 @@ description: "Manage AI agent skills for GitButler."
 Skills provide enhanced AI capabilities for working with GitButler through
 Claude Code, Codex, and other AI assistants.
 
+For most agent setup, use [`but agent setup`](/commands/but-agent). It wraps
+skill installation with workflow instructions. Use `but skill` when you only
+need to install, update, check, or place the skill files yourself.
+
 Use `but skill install` to install the GitButler skill files. By default,
 it prompts for scope (repository or global home directory) and then format.
 When run outside a git repository, local scope is unavailable and the

--- a/content/docs/commands/commands-overview.mdx
+++ b/content/docs/commands/commands-overview.mdx
@@ -63,4 +63,5 @@ description: Your fast index to all of the available commands
 - [update](./but-update): Manage GitButler CLI and app updates
 - [alias](./but-alias): Manage command aliases
 - [config](./but-config): View and manage GitButler configuration
+- [agent](./but-agent): Set up GitButler for AI coding agents
 - [skill](./but-skill): Manage AI agent skills for GitButler

--- a/content/docs/commands/meta.json
+++ b/content/docs/commands/meta.json
@@ -46,6 +46,7 @@
     "but-update",
     "but-alias",
     "but-config",
+    "but-agent",
     "but-skill"
   ]
 }


### PR DESCRIPTION
Adds documentation for the new `but agent` command and makes `but agent setup` the primary path for configuring coding agents.

## What changed

- **New command reference** `commands/but-agent.mdx`, listed in the commands index and `meta.json`.
- **`ai-agents/getting-started`** rewritten around the setup wizard: drops the legacy paste-in `## Version control` baseline and the `but skill install` walkthrough, keeps the workspace-mode (`but setup`) section, and mentions `but skill` for updating an installed skill.
- **`ai-agents/overview`** gains a Quick start; tuning and CLI tutorial docs now point at the wizard.
- Cross-links `but skill` ↔ `but agent`, and repoints `parallel-agents` to the new instructions section.

## Why

`but agent setup` wraps skill install + workflow instructions + repository setup into one wizard, so the docs should lead with it instead of the manual, copy-paste flow.