### PR TITLE
fix(ci): prevent docs update if PR already exists

### DIFF
--- a/.github/workflows/update-generated-docs.yml
+++ b/.github/workflows/update-generated-docs.yml
@@ -22,8 +22,10 @@ jobs:
       - run: |
           git clone https://github.com/gitbutlerapp/gitbutler ../gitbutler
 
-      - name: Compare versions
+      - name: Check version and pull request
         id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GH_CREATE_PR_PAT }}
         run: |
           CURRENT_DOCS_VERSION=$(cat scripts/current_docs_version.txt)
           LATEST_VERSION=$(git -C ../gitbutler tag --list 'release/*' --sort=-version:refname | head -n 1)
@@ -33,12 +35,25 @@ jobs:
 
           test -n "$LATEST_VERSION"
 
-          echo "latest_version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          PR_TITLE="Update generated CLI documentation for version ${LATEST_VERSION}"
 
-          if [ "$LATEST_VERSION" != "$CURRENT_DOCS_VERSION" ]; then
-            echo "should_update=true" >> "$GITHUB_OUTPUT"
-          else
+          echo "latest_version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$PR_TITLE" >> "$GITHUB_OUTPUT"
+
+          if [ "$LATEST_VERSION" = "$CURRENT_DOCS_VERSION" ]; then
             echo "should_update=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          branch="update-generated-docs-$LATEST_VERSION"
+          existing_pr_url=$(gh pr list --state open --head "$branch" --json url --jq '.[0].url // empty')
+
+          if [ -n "$existing_pr_url" ]; then
+            echo "Pull request already exists for $LATEST_VERSION: $existing_pr_url"
+            echo "should_update=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No existing pull request for $LATEST_VERSION"
+            echo "should_update=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update generated docs
@@ -70,10 +85,13 @@ jobs:
         if: steps.versions.outputs.should_update == 'true'
         run: |
           gh pr create \
-            --title "Update generated CLI documentation for version ${LATEST_VERSION}" \
-            --body "Automatic docs update for ${LATEST_VERSION} @slarse @krlvi" \
+            --title "$PR_TITLE" \
+            --body "Automatic docs update for ${LATEST_VERSION}" \
+            --assignee krlvi \
+            --assignee slarse \
             --base main \
             --head "$branch"
         env:
           GH_TOKEN: ${{ secrets.GH_CREATE_PR_PAT }}
           LATEST_VERSION: ${{ steps.versions.outputs.latest_version }}
+          PR_TITLE: ${{ steps.versions.outputs.pr_title }}


### PR DESCRIPTION
Currently, the workflow runs again and fails as the branch is there.