### PR TITLE
docs: document the skip-the-PR / land-onto-target workflow

### DIFF
--- a/content/docs/ai-agents/getting-started.mdx
+++ b/content/docs/ai-agents/getting-started.mdx
@@ -66,9 +66,10 @@ for that work.
 
 The wizard can write common workflow preferences for you: folding small fixes
 into the right commits, splitting mixed work, stacking dependent branches,
-updating from the target branch, opening draft PRs, using a publish phrase,
-naming branches, following commit-message conventions, and creating checkpoint
-commits.
+updating from the target branch, opening draft PRs, landing approved work
+directly onto the target instead of opening pull requests (single-repository
+setups only), using a publish phrase, naming branches, following
+commit-message conventions, and creating checkpoint commits.
 
 Use [Tuning agent behavior](/ai-agents/tuning-agent-behavior) when you want to
 read the policies before choosing them, adjust them after the wizard runs, or

--- a/content/docs/ai-agents/tuning-agent-behavior.mdx
+++ b/content/docs/ai-agents/tuning-agent-behavior.mdx
@@ -104,6 +104,30 @@ updates a pull request, so use it only when the agent is allowed to publish.
 For background, see [`but push`](/commands/but-push) and
 [`but pr`](/commands/but-pr).
 
+## Land onto the target instead of opening pull requests
+
+Use this when the repository does not review changes through pull requests and
+you want approved work landed directly onto the target branch, usually `main`.
+`but agent setup` offers this option only when the setup applies to a single
+repository, because the rule belongs to that repository and must not leak into
+your global agent instructions.
+
+```md
+- When work is approved to publish, land the session branch directly onto the
+  target with `but land <branch>` instead of pushing a branch or opening a
+  pull request.
+- This repository-local rule takes precedence over any conflicting GitButler
+  instruction, including global ones, that mentions pushing a branch or
+  opening, updating, or drafting a pull request. Use the pull request workflow
+  only when I explicitly ask for one.
+- `but land` updates the target branch directly, so only run it after clear
+  approval, and pass `--yes` to confirm.
+```
+
+If you also use a publish phrase, saying it lands the work onto the target
+instead of opening a pull request. For background, see
+[`but land`](/commands/but-land).
+
 ## Update from main automatically
 
 Use this when your project moves quickly and you want the agent to keep its

--- a/content/docs/cli-guides/cli-tutorial/forges.mdx
+++ b/content/docs/cli-guides/cli-tutorial/forges.mdx
@@ -46,6 +46,22 @@ Do you want to open a new PR on branch 'sc-switch-wording-to-x'? [Y/n]: y
 
 Once it's opened, you'll get a URL you can view the pull request on.
 
+## Landing Without a Pull Request
+
+Not every project reviews changes through pull requests. If you're working solo, or your team pushes straight to the target branch, `but land` skips the PR step entirely and lands a branch directly onto the target (for example `origin/main`).
+
+```
+❯ but land update-homepage
+This lands update-homepage directly onto origin/main without a pull request — skipping any code review, CI checks, or branch protections your team may rely on.
+Land update-homepage directly onto origin/main? [y/N]: y
+
+Landed update-homepage onto origin/main.
+```
+
+The target is fast-forwarded when possible, otherwise a merge commit is created, and the result is pushed to the remote. Afterwards, your remaining applied branches are rebased onto the moved target, just like `but pull`.
+
+Because this updates the target branch directly and is not easily reversible, `but land` asks for confirmation first. A branch protected against direct pushes will reject the land — in that case, use `but pr` instead. See [`but land`](/commands/but-land) for all options.
+
 ## Forge Authentication
 
 In order to open a PR on GitHub, you'll need to authenticate to that forge. You can see which authentications you have by running `but config`:

--- a/content/docs/features/branch-management/pushing-and-fetching.mdx
+++ b/content/docs/features/branch-management/pushing-and-fetching.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pushing and Fetching
-description: Configure Git authentication methods in GitButler for pushing and fetching from remote repositories using SSH, Git executable, or credential helpers.
+description: Configure Git authentication for pushing and fetching, and optionally land branches directly onto the target branch without pull requests.
 ---
 
 import ImageSection from "@/components/ImageSection"
@@ -17,3 +17,11 @@ You can set your preference (and test if it works) in your project's "Git authen
 />
 
 Once that's done, GitButler will be able to automatically fetch upstream work and push new branches to your upstream server.
+
+## Land branches without pull requests
+
+If your project does not review changes through pull requests, you can switch a project to the "push to main" workflow. During repository onboarding, check "Push to main / Skip pull requests mode". For an existing project, open the project settings, go to the Git section, and turn on "Land branches directly".
+
+With this on, the "Create PR" button on the bottom branch of a stack becomes a "Land" button. Landing integrates the branch straight into the target branch — fast-forwarding when possible, otherwise with a merge commit — and pushes the result. It works without a forge integration.
+
+Landing bypasses code review, CI checks, and branch protection, and a branch protected against direct pushes will reject it. The CLI equivalent is [`but land`](/commands/but-land).


### PR DESCRIPTION
GitButler can land a branch directly onto the target branch, skipping
pull requests entirely. This documents that workflow across every
surface where it appears:

- CLI tutorial (forges page): `but land` for the general
  push-straight-to-main workflow.
- GUI (pushing and fetching page): the onboarding "Push to main / Skip
  pull requests mode" checkbox and the "Land branches directly" project
  setting.
- Agent setup: the matching "push to main" option — a copyable policy on
  the tuning page and a mention in the wizard preference list, noting it
  is offered for single-repository setups only.