### PR TITLE
docs: fix hunk id of bookmark.rb

### DIFF
--- a/content/docs/cli-guides/cli-tutorial/branching-and-commiting.mdx
+++ b/content/docs/cli-guides/cli-tutorial/branching-and-commiting.mdx
@@ -190,7 +190,7 @@ We will assign each file to a different branch and then see the result. We assig
 
 You can either stage the file identifier that you see next to each file, or all or part of the file path. For example, in this case to identify the `app/models/bookmark.rb` file, you can do either:
 
-- `g0`
+- `i0`
 - `app/models/bookmark.rb`
 
 So lets stage the bookmark changes to the bookmarks branch:


### PR DESCRIPTION
## 🧢 Changes

Update hunk id of bookmark.rb from `g0` to `i0`

## ☕️ Reasoning

There is hunk id in-consistency of the bookmark.rb

<img width="1724" height="938" alt="image" src="https://github.com/user-attachments/assets/c8022acf-fff3-4dfc-bf9f-212d66369bae" />

<img width="860" height="177" alt="image" src="https://github.com/user-attachments/assets/9f7d8be9-3fdd-433d-8e19-1faf20ec0cfc" />



<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
