### PR TITLE
Update Git authentication documentation

### DIFF
--- a/content/docs/features/branch-management/pushing-and-fetching.mdx
+++ b/content/docs/features/branch-management/pushing-and-fetching.mdx
@@ -1,22 +1,15 @@
 ---
-title: Pushing and Fetching
-description: Configure Git authentication for pushing and fetching, and optionally land branches directly onto the target branch without pull requests.
+title: Push and fetch
+description: Use your system Git authentication to push and fetch, or land branches directly onto the target branch without pull requests.
 ---
 
-import ImageSection from "@/components/ImageSection"
+GitButler uses your system Git executable to authenticate with your remote. This means it uses the same SSH configuration, SSH agent, or [credential helper](https://git-scm.com/doc/credential-helpers) as Git in your terminal.
 
-GitButler can authenticate with an upstream Git server in several different ways.
+Open your project settings, go to the Git section, and select **Test credentials** to verify that GitButler can push to the remote. The test pushes an existing commit to a temporary remote branch and removes the branch after the check.
 
- You can just tell us to use the system Git executable, which you can setup however you want. You can use our built in SSH protocol with your own SSH key (this does not require you to have Git installed), or you can use the default [Git credentials helper](https://git-scm.com/doc/credential-helpers).
+If the test fails, configure authentication for your system Git first, then run the test again. GitButler no longer has separate settings for selecting an SSH key or credential helper.
 
-You can set your preference (and test if it works) in your project's "Git authentication" section:
-
-<ImageSection
-  alt="Git Authentication Settings"
-  src="/pushing.png"
-/>
-
-Once that's done, GitButler will be able to automatically fetch upstream work and push new branches to your upstream server.
+Once authentication works, GitButler can automatically fetch upstream work and push new branches to your remote.
 
 ## Land branches without pull requests
 

--- a/content/docs/guide.mdx
+++ b/content/docs/guide.mdx
@@ -37,15 +37,11 @@ If you would like to use our AI features like commit message generation, you can
 
 You can also connect GitButler to your GitHub account so we can automatically open Pull Requests for you (this is also optional).
 
-## Set Up Git Authentication
+## Test Git authentication
 
-In order to push to a remote repository, you will need to set up your Git authentication. We provide three ways to do this, but generally it's easiest to use the existing Git executable. You can hit the "Test credentials" button to make sure everything is working properly.
+GitButler uses your system Git executable and its existing authentication configuration. Open the Git section in your project settings and select **Test credentials** to make sure GitButler can push to the remote.
 
-<ImageSection
-  alt="Git configuration screen"
-  src="/started/setup-git.png"
-  subtitle="Second step: configure your git pushes"
-/>
+If the test fails, configure authentication for Git in your terminal first, then run the test again.
 
 ## Ready to Go
 

--- a/content/docs/troubleshooting/fetch-push.mdx
+++ b/content/docs/troubleshooting/fetch-push.mdx
@@ -1,12 +1,11 @@
 ---
-title: Fetch / Push Issues
-description: Troubleshoot Git authentication issues and configure various push/fetch methods including SSH keys and credential helpers.
+title: Fix fetch and push issues
+description: Troubleshoot remote authentication and automatic fetching in GitButler.
 ---
 
-import ImageSection from "@/components/ImageSection"
 import { Tab, Tabs } from "fumadocs-ui/components/tabs"
 
-If you are having trouble pushing or fetching from a remote, this is likely related to git authentication. Here are a few configuration options you can try out, found in the project settings.
+GitButler uses your system Git executable to communicate with remotes. If pushing or fetching fails, check that your system Git can authenticate with the same remote.
 
 ## Configuring the auto-fetch frequency
 
@@ -30,65 +29,16 @@ The file is in JSONC format and follows the [following schema](https://github.co
 
 A negative value (e.g. -1) disables auto fetching. Note that if `fetch` is the only entry in the JSON file, you may want to enclose it in a top-level object.
 
-## Available authentication methods
+## Check Git authentication
 
-GitButler can be configured to use several different git authentication methods. You can switch between them in your project settings. You can try multiple different options and see if any of them are appropriate for your setup. Note that if you are on Windows, the only applicable method is the "Git executable", therefore the application will now show this as a configuration option. 
+GitButler no longer provides separate authentication modes for selecting an SSH key or credential helper. Configure authentication for your system Git instead:
 
-<ImageSection
-  alt="Parallel Branches Example"
-  src="/issues-01.png"
-/>
+1. In the repository, run `git fetch` from your terminal.
+2. If it fails, fix your Git authentication. Configure SSH through your SSH agent and `~/.ssh/config`, or configure an HTTPS [credential helper](https://git-scm.com/doc/credential-helpers).
+3. In GitButler, open the project's settings, go to the Git section, and select **Test credentials**.
 
-### Use a Git executable (default)
+SSH keys managed by tools such as 1Password or backed by a FIDO security key work when they are available to your system Git through the SSH agent.
 
-The default way to push and fetch is for GitButler to use an existing system Git executable. This should use whatever authentication mechanism that Git uses for the remote that you're trying to push to or fetch from.
+## Get more help
 
-### Use an existing SSH key
-
-If already have an SSH key set up (eg. `~/.ssh/id_rsa`), you can instruct GitButler to use it. In case the key is password protected, you can also provide the password to it (which will be stored locally).
-
-### Use locally generated SSH key
-
-This option generates a new SSH key which will be stored locally in the application [data dir](https://docs.gitbutler.com/development/debugging#data-files). For this to work you will need to add the new public key to your Git remote provider.
-
-### Use a git credential helper
-
-If your system is set up with a credential helper, GitButler can use that. For more info on git credential helpers, see this [article](https://git-scm.com/doc/credential-helpers).
-
-### FIDO security keys (YubiKey, etc.)
-
-If you're using a FIDO key, check out this issue to see how people have set it up with the Git executable method: [#2661](https://github.com/gitbutlerapp/gitbutler/issues/2661)
-
-### Keys managed by 1Password
-
-Keys stored in 1Password should properly use it as an SSH agent for authentication and signing commits if you use the Git executable option. (Previously tracked in [#2779](https://github.com/gitbutlerapp/gitbutler/issues/2779))
-
-### Host certificate checks
-
-There is an option to ignore host certificate checks when authenticating with ssh. This may be a helpful option to enable in some cases.
-
-## Other known issues
-
-### Git remote servers with a non-standard SSH port
-In some cases, the git remote may be setup on a port number other than 22. If the port is set in your `~/.ssh/config` file, GitButler will not be able to recognize that - tracked in GitHub issue [#2700](https://github.com/gitbutlerapp/gitbutler/issues/2700).
-
-As a workaround you may set your remote in the [SSH format](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols) (eg. `ssh://git@example.com:3022/foo/bar.git`)
-
-Updating parallel branches when the respective remote has new commits
-If you have added a remote branch to your active workspace in GitButler, or pushed a virtual branch to the remote, and new commits are added to the remote branch, there is currently no way to sync those new commits into the existing virtual branch in GitButler. This is being tracked in the GitHub issue [#2649](https://github.com/gitbutlerapp/gitbutler/issues/2649).
-
-The current workaround is to undo any local commits and then stash your local changes manually using [git stash](https://git-scm.com/docs/git-stash) and then delete the virtual branch that has upstream changes. Then you can update the trunk by clicking the update button next to the word "Trunk" in the sidebar on the left to make sure all new upstream changes are synced, then select the remote branch that has the new changes and click the "Apply +" button above the list of commits for the branch. Once the updated branch is applied to your working directory, you can manually `git stash pop` your stashed changes and then resolve any merge conflicts.
-
-### OAuth app access restrictions on your GitHub organization
-
-If you're submitting code and PRs to a repository under an organization on GitHub, you may receive an error that, despite having correct authorization credentials, your organization has enabled OAuth app access restrictions. These restrictions are an organization-level security feature designed to prevent unauthorized third-party applications from accessing organization resources.
-
-To solve this, go to Applications. Select the "Authorized OAuth Apps" tab, and look for "GitButler Client". If you don't find "GitButler Client", it's possible you haven't yet set GitButler up for personal use. If so, try creating a test commit on a test branch for a personal repository using GitButler, which you can delete after, then check the same tab as before.
-
-If you see "GitButler Client", click on it and, under "Organization Access", across from the organization you wish to enable GitButler for, click either the "Request" or "Grant" button, depending on whether you are a contributor or owner, respectively. If you're a contributor clicking "Request", note that you'll need to wait for an organization owner to approve your access request before you can proceed.
-
-Note for organization owners: To streamline this process for your team members, you can pre-approve GitButler for all organization members. This eliminates the need for individual access requests and approvals. This can be managed through your organization's OAuth app access settings.
-
-### Help on Discord
-If none of the available options helps, feel free to hop on our [Discord](https://discord.gg/MmFkmaJ42D) and we will be happy to help you out.
-
+If system Git can fetch and push but GitButler still fails, share the error and your [GitButler logs](/development/debugging#logs) in our [Discord](https://discord.gg/MmFkmaJ42D).

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -379,15 +379,11 @@ If you would like to use our AI features like commit message generation, you can
 
 You can also connect GitButler to your GitHub account so we can automatically open Pull Requests for you (this is also optional).
 
-## Set Up Git Authentication
+## Test Git authentication
 
-In order to push to a remote repository, you will need to set up your Git authentication. We provide three ways to do this, but generally it's easiest to use the existing Git executable. You can hit the "Test credentials" button to make sure everything is working properly.
+GitButler uses your system Git executable and its existing authentication configuration. Open the Git section in your project settings and select **Test credentials** to make sure GitButler can push to the remote.
 
-<ImageSection
-  alt="Git configuration screen"
-  src="/started/setup-git.png"
-  subtitle="Second step: configure your git pushes"
-/>
+If the test fails, configure authentication for Git in your terminal first, then run the test again.
 
 ## Ready to Go
 
@@ -1014,7 +1010,7 @@ branch, you can then push it to your remote via `git push`.
 # fetch-push.mdx
 
 
-If you are having trouble pushing or fetching from a remote, this is likely related to git authentication. Here are a few configuration options you can try out, found in the project settings.
+GitButler uses your system Git executable to communicate with remotes. If pushing or fetching fails, check that your system Git can authenticate with the same remote.
 
 ## Configuring the auto-fetch frequency
 
@@ -1038,67 +1034,19 @@ The file is in JSONC format and follows the [following schema](https://github.co
 
 A negative value (e.g. -1) disables auto fetching. Note that if `fetch` is the only entry in the JSON file, you may want to enclose it in a top-level object.
 
-## Available authentication methods
+## Check Git authentication
 
-GitButler can be configured to use several different git authentication methods. You can switch between them in your project settings. You can try multiple different options and see if any of them are appropriate for your setup. Note that if you are on Windows, the only applicable method is the "Git executable", therefore the application will now show this as a configuration option.
+GitButler no longer provides separate authentication modes for selecting an SSH key or credential helper. Configure authentication for your system Git instead:
 
-<ImageSection
-  alt="Parallel Branches Example"
-  src="/issues-01.png"
-/>
+1. In the repository, run `git fetch` from your terminal.
+2. If it fails, fix your Git authentication. Configure SSH through your SSH agent and `~/.ssh/config`, or configure an HTTPS [credential helper](https://git-scm.com/doc/credential-helpers).
+3. In GitButler, open the project's settings, go to the Git section, and select **Test credentials**.
 
-### Use a Git executable (default)
+SSH keys managed by tools such as 1Password or backed by a FIDO security key work when they are available to your system Git through the SSH agent.
 
-The default way to push and fetch is for GitButler to use an existing system Git executable. This should use whatever authentication mechanism that Git uses for the remote that you're trying to push to or fetch from.
+## Get more help
 
-### Use an existing SSH key
-
-If already have an SSH key set up (eg. `~/.ssh/id_rsa`), you can instruct GitButler to use it. In case the key is password protected, you can also provide the password to it (which will be stored locally).
-
-### Use locally generated SSH key
-
-This option generates a new SSH key which will be stored locally in the application [data dir](https://docs.gitbutler.com/development/debugging#data-files). For this to work you will need to add the new public key to your Git remote provider.
-
-### Use a git credential helper
-
-If your system is set up with a credential helper, GitButler can use that. For more info on git credential helpers, see this [article](https://git-scm.com/doc/credential-helpers).
-
-### FIDO security keys (YubiKey, etc.)
-
-If you're using a FIDO key, check out this issue to see how people have set it up with the Git executable method: [#2661](https://github.com/gitbutlerapp/gitbutler/issues/2661)
-
-### Keys managed by 1Password
-
-Keys stored in 1Password should properly use it as an SSH agent for authentication and signing commits if you use the Git executable option. (Previously tracked in [#2779](https://github.com/gitbutlerapp/gitbutler/issues/2779))
-
-### Host certificate checks
-
-There is an option to ignore host certificate checks when authenticating with ssh. This may be a helpful option to enable in some cases.
-
-## Other known issues
-
-### Git remote servers with a non-standard SSH port
-In some cases, the git remote may be setup on a port number other than 22. If the port is set in your `~/.ssh/config` file, GitButler will not be able to recognize that - tracked in GitHub issue [#2700](https://github.com/gitbutlerapp/gitbutler/issues/2700).
-
-As a workaround you may set your remote in the [SSH format](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols) (eg. `ssh://git@example.com:3022/foo/bar.git`)
-
-Updating parallel branches when the respective remote has new commits
-If you have added a remote branch to your active workspace in GitButler, or pushed a virtual branch to the remote, and new commits are added to the remote branch, there is currently no way to sync those new commits into the existing virtual branch in GitButler. This is being tracked in the GitHub issue [#2649](https://github.com/gitbutlerapp/gitbutler/issues/2649).
-
-The current workaround is to undo any local commits and then stash your local changes manually using [git stash](https://git-scm.com/docs/git-stash) and then delete the virtual branch that has upstream changes. Then you can update the trunk by clicking the update button next to the word "Trunk" in the sidebar on the left to make sure all new upstream changes are synced, then select the remote branch that has the new changes and click the "Apply +" button above the list of commits for the branch. Once the updated branch is applied to your working directory, you can manually `git stash pop` your stashed changes and then resolve any merge conflicts.
-
-### OAuth app access restrictions on your GitHub organization
-
-If you're submitting code and PRs to a repository under an organization on GitHub, you may receive an error that, despite having correct authorization credentials, your organization has enabled OAuth app access restrictions. These restrictions are an organization-level security feature designed to prevent unauthorized third-party applications from accessing organization resources.
-
-To solve this, go to Applications. Select the "Authorized OAuth Apps" tab, and look for "GitButler Client". If you don't find "GitButler Client", it's possible you haven't yet set GitButler up for personal use. If so, try creating a test commit on a test branch for a personal repository using GitButler, which you can delete after, then check the same tab as before.
-
-If you see "GitButler Client", click on it and, under "Organization Access", across from the organization you wish to enable GitButler for, click either the "Request" or "Grant" button, depending on whether you are a contributor or owner, respectively. If you're a contributor clicking "Request", note that you'll need to wait for an organization owner to approve your access request before you can proceed.
-
-Note for organization owners: To streamline this process for your team members, you can pre-approve GitButler for all organization members. This eliminates the need for individual access requests and approvals. This can be managed through your organization's OAuth app access settings.
-
-### Help on Discord
-If none of the available options helps, feel free to hop on our [Discord](https://discord.gg/MmFkmaJ42D) and we will be happy to help you out.
+If system Git can fetch and push but GitButler still fails, share the error and your [GitButler logs](/development/debugging#logs) in our [Discord](https://discord.gg/MmFkmaJ42D).
 
 
 
@@ -2155,18 +2103,13 @@ If you're using GitHub integration and the branch has an associated pull request
 # pushing-and-fetching.mdx
 
 
-GitButler can authenticate with an upstream Git server in several different ways.
+GitButler uses your system Git executable to authenticate with your remote. This means it uses the same SSH configuration, SSH agent, or [credential helper](https://git-scm.com/doc/credential-helpers) as Git in your terminal.
 
- You can just tell us to use the system Git executable, which you can setup however you want. You can use our built in SSH protocol with your own SSH key (this does not require you to have Git installed), or you can use the default [Git credentials helper](https://git-scm.com/doc/credential-helpers).
+Open your project settings, go to the Git section, and select **Test credentials** to verify that GitButler can push to the remote. The test pushes an existing commit to a temporary remote branch and removes the branch after the check.
 
-You can set your preference (and test if it works) in your project's "Git authentication" section:
+If the test fails, configure authentication for your system Git first, then run the test again. GitButler no longer has separate settings for selecting an SSH key or credential helper.
 
-<ImageSection
-  alt="Git Authentication Settings"
-  src="/pushing.png"
-/>
-
-Once that's done, GitButler will be able to automatically fetch upstream work and push new branches to your upstream server.
+Once authentication works, GitButler can automatically fetch upstream work and push new branches to your remote.
 
 
 # rules.mdx


### PR DESCRIPTION
GitButler now relies on system Git for remote authentication, but several pages still described the removed authentication picker.

- document system Git authentication and credential testing
- remove obsolete authentication modes and screenshots
- update troubleshooting guidance and the LLM documentation bundle