### PR TITLE
Fix command docs MDX placeholders

### DIFF
--- a/content/docs/commands/but-move.mdx
+++ b/content/docs/commands/but-move.mdx
@@ -14,13 +14,13 @@ may be created as part of the move.
 
 **A branch is created when:**
 
-* You move a commit or committed file relative to a branch
-* You unstack a commit or committed file
+- You move a commit or committed file relative to a branch
+- You unstack a commit or committed file
 
 **A commit is created when:**
 
-* You move a committed file relative to a commit or branch
-* You unstack a committed file
+- You move a committed file relative to a commit or branch
+- You unstack a committed file
 
 Note the overlap between the above conditions. For example, unstacking a committed file both
 creates a new commit for the file and a branch for the commit.
@@ -31,7 +31,7 @@ For more details about CLI IDs, see `but help cli-ids`.
 
 ## Arguments
 
-* `<SOURCES>` — One or more sources to move.
+- `<SOURCES>` — One or more sources to move.
 
 You may provide one of the following kinds of sources:
 
@@ -49,33 +49,36 @@ Providing any of the sources as an argument for a target such as --above or --be
 
 ## Options
 
-* `-b`, `--branch` `<BRANCH>` — Place <SOURCES> on the branch BRANCH.
+- `-b`, `--branch` `<BRANCH>` — Place `<SOURCES>` on the branch BRANCH.
 
 If BRANCH does not exist, it is created as an unstacked branch.
 
 If BRANCH is omitted, an unstacked branch with a generated name is created. This is exactly equivalent to --unstack and is allowed for any source kind.
 
-If BRANCH is provided, <SOURCES> must be either commits or committed files.
+If BRANCH is provided, `<SOURCES>` must be either commits or committed files.
 
-Attempting to place <SOURCES> on a branch that exists but is not applied is an error.
-* `-A`, `--above` `<BRANCH_OR_COMMIT>` — Place <SOURCES> above BRANCH_OR_COMMIT, which must be an applied branch or commit.
+Attempting to place `<SOURCES>` on a branch that exists but is not applied is an error.
 
-If BRANCH_OR_COMMIT is a commit, <SOURCES> are placed on the same branch as the targeted commit.
+- `-A`, `--above` `<BRANCH_OR_COMMIT>` — Place `<SOURCES>` above BRANCH_OR_COMMIT, which must be an applied branch or commit.
+
+If BRANCH_OR_COMMIT is a commit, `<SOURCES>` are placed on the same branch as the targeted commit.
 
 If BRANCH_OR_COMMIT is a branch, the sources are placed on a new branch above the targeted branch.
 
-This target is applicable for all kinds of <SOURCES>.
-* `-B`, `--below` `<BRANCH_OR_COMMIT>` — Place <SOURCES> below BRANCH_OR_COMMIT, which must be an applied branch or commit.
+This target is applicable for all kinds of `<SOURCES>`.
 
-If BRANCH_OR_COMMIT is a commit, the <SOURCES> are placed on the same branch as the targeted commit.
+- `-B`, `--below` `<BRANCH_OR_COMMIT>` — Place `<SOURCES>` below BRANCH_OR_COMMIT, which must be an applied branch or commit.
 
-If BRANCH_OR_COMMIT is a branch, <SOURCES> are placed on a new branch below the targeted branch. Branches are treated as buckets, meaning that "below a branch" is treated as below the oldest ancestor on that branch.
+If BRANCH_OR_COMMIT is a commit, the `<SOURCES>` are placed on the same branch as the targeted commit.
 
-This target is only applicable for <SOURCES> that are commits or committed files.
-* `--unstack` — Unstack <SOURCES> from their current stacks.
+If BRANCH_OR_COMMIT is a branch, `<SOURCES>` are placed on a new branch below the targeted branch. Branches are treated as buckets, meaning that "below a branch" is treated as below the oldest ancestor on that branch.
 
---unstack does not take an argument, so --unstack <SOURCES> and <SOURCES> --unstack are equivalent.
-* `--allow-merged` — Allow targeting branches and commits that are already merged upstream.
+This target is only applicable for `<SOURCES>` that are commits or committed files.
+
+- `--unstack` — Unstack `<SOURCES>` from their current stacks.
+
+--unstack does not take an argument, so `--unstack <SOURCES>` and `<SOURCES> --unstack` are equivalent.
+
+- `--allow-merged` — Allow targeting branches and commits that are already merged upstream.
 
 By default, mutations refuse to touch history that has landed in the target branch, since the results tend to conflict on the next but pull.
-

--- a/content/docs/commands/but-squash.mdx
+++ b/content/docs/commands/but-squash.mdx
@@ -21,52 +21,56 @@ For more details about CLI IDs, see `but help cli-ids`.
 
 ## Arguments
 
-* `<SOURCES>` — The sources to squash.
+- `<SOURCES>` — The sources to squash.
 
-If --target is provided and <SOURCES> is omitted, the uncommitted area (zz) is used.
+If --target is provided and `<SOURCES>` is omitted, the uncommitted area (zz) is used.
 
-If <SOURCES> is one or more commits they will be squashed into the target.
+If `<SOURCES>` is one or more commits they will be squashed into the target.
 
-If <SOURCES> is one or more branches all the commits on the branches will be squashed into the target and the branches will be removed.
+If `<SOURCES>` is one or more branches all the commits on the branches will be squashed into the target and the branches will be removed.
 
-If TARGET is omitted and <SOURCES> is exactly one branch all commits on the branch will be squashed.
+If TARGET is omitted and `<SOURCES>` is exactly one branch all commits on the branch will be squashed.
 
-If <SOURCES> is one or more uncommitted files or hunks they will be squashed into the target.
+If `<SOURCES>` is one or more uncommitted files or hunks they will be squashed into the target.
 
-If <SOURCES> is the uncommitted area (zz) all uncommitted changes will be squashed into the target.
+If `<SOURCES>` is the uncommitted area (zz) all uncommitted changes will be squashed into the target.
 
-If <SOURCES> is a committed file those changes will be moved into the target. All changes must come from the same commit. It is not possible to move changes from multiple source commits into a single target.
+If `<SOURCES>` is a committed file those changes will be moved into the target. All changes must come from the same commit. It is not possible to move changes from multiple source commits into a single target.
 
 It is not possible to mix sources of different types, i.e., all sources must either be commits, branches, uncommitted files, zz, or committed files.
 
 ## Options
 
-* `-m`, `--message` `<MESSAGE>` — The message to use for the new commit.
+- `-m`, `--message` `<MESSAGE>` — The message to use for the new commit.
 
 Can be supplied any number of times, each value being appended to the preceding ones with a blank line in between.
 
 This cannot be used when TARGET is the uncommitted area (zz).
-* `--no-message` — Creates the commit without a commit message.
+
+- `--no-message` — Creates the commit without a commit message.
 
 This cannot be used when TARGET is the uncommitted area (zz).
-* `-u`, `--use-target-message` — Use the message of the target.
+
+- `-u`, `--use-target-message` — Use the message of the target.
 
 The message of the source(s) will be discarded.
 
 This cannot be used when TARGET is the uncommitted area (zz).
-* `--use-source-message` — Use the message of the source(s).
+
+- `--use-source-message` — Use the message of the source(s).
 
 The message of the target will be discarded.
 
-Cannot be used if <SOURCES> are not committed, if TARGET is the uncommitted area (zz), or if moving committed changes between commits.
-* `-t`, `--target` `<TARGET>` — The target to squash into.
+Cannot be used if `<SOURCES>` are not committed, if TARGET is the uncommitted area (zz), or if moving committed changes between commits.
+
+- `-t`, `--target` `<TARGET>` — The target to squash into.
 
 If TARGET is a commit the sources will be added to the commit.
 
 If TARGET is a branch the sources will be added to that branch's newest commit (its tip).
 
 If TARGET is the uncommitted area (zz) the sources will be uncommitted.
-* `--allow-merged` — Allow targeting branches and commits that are already merged upstream.
+
+- `--allow-merged` — Allow targeting branches and commits that are already merged upstream.
 
 By default, mutations refuse to touch history that has landed in the target branch, since the results tend to conflict on the next but pull.
-

--- a/content/docs/commands/but-uncommit.mdx
+++ b/content/docs/commands/but-uncommit.mdx
@@ -9,13 +9,12 @@ For more details about CLI IDs, see `but help cli-ids`.
 
 ## Arguments
 
-* `<SOURCES>` — One or more commits or committed files to uncommit.
+- `<SOURCES>` — One or more commits or committed files to uncommit.
 
-A whole commit is uncommitted by its commit ID; a single file is uncommitted with <commit-id>:<file-id>. (required)
+A whole commit is uncommitted by its commit ID; a single file is uncommitted with `<commit-id>:<file-id>`. (required)
 
 ## Options
 
-* `--allow-merged` — Allow targeting branches and commits that are already merged upstream.
+- `--allow-merged` — Allow targeting branches and commits that are already merged upstream.
 
 By default, mutations refuse to touch history that has landed in the target branch, since the results tend to conflict on the next but pull.
-


### PR DESCRIPTION
Escapes generated command placeholders so MDX does not parse them as JSX.